### PR TITLE
Suppress RapidJSON warning to allow gcc>=8 compilation

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -25,10 +25,13 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+// Disable class-memaccess warning to facilitate compilation with gcc>7
+// https://github.com/Tencent/rapidjson/issues/1700
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #include <rapidjson/document.h>
 #pragma GCC diagnostic pop
+
 #include <rapidjson/error/en.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/rapidjson.h>
@@ -140,8 +143,6 @@ class TritonJson {
         TRITONJSON_STATUSRETURN(
             std::string("JSON parsing only available for top-level document"));
       }
-      // Disable class-memaccess warning to facilitate compilation with gcc>7
-      // https://github.com/Tencent/rapidjson/issues/1700
       document_.Parse(base, size);
       if (document_.HasParseError()) {
         TRITONJSON_STATUSRETURN(std::string(

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -140,7 +140,7 @@ class TritonJson {
       // Disable class-memaccess warning to facilitate compilation with gcc>7
       // https://github.com/Tencent/rapidjson/issues/1700
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#pragma GCC diagnostic ignored "-Werror=class-memaccess"
       document_.Parse(base, size);
 #pragma GCC diagnostic pop
       if (document_.HasParseError()) {

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -25,7 +25,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
 #include <rapidjson/document.h>
+#pragma GCC diagnostic pop
 #include <rapidjson/error/en.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/rapidjson.h>
@@ -139,10 +142,7 @@ class TritonJson {
       }
       // Disable class-memaccess warning to facilitate compilation with gcc>7
       // https://github.com/Tencent/rapidjson/issues/1700
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=class-memaccess"
       document_.Parse(base, size);
-#pragma GCC diagnostic pop
       if (document_.HasParseError()) {
         TRITONJSON_STATUSRETURN(std::string(
             "failed to parse the request JSON buffer: " +

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -28,7 +28,9 @@
 // Disable class-memaccess warning to facilitate compilation with gcc>7
 // https://github.com/Tencent/rapidjson/issues/1700
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <rapidjson/document.h>
 #pragma GCC diagnostic pop
 

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -137,7 +137,12 @@ class TritonJson {
         TRITONJSON_STATUSRETURN(
             std::string("JSON parsing only available for top-level document"));
       }
+      // Disable class-memaccess warning to facilitate compilation with gcc>7
+      // https://github.com/Tencent/rapidjson/issues/1700
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
       document_.Parse(base, size);
+#pragma GCC diagnostic pop
       if (document_.HasParseError()) {
         TRITONJSON_STATUSRETURN(std::string(
             "failed to parse the request JSON buffer: " +


### PR DESCRIPTION
Suppress `class-memaccess` warnings in RapidJSON header to work around https://github.com/Tencent/rapidjson/issues/1700.
This change allows compilation with gcc>=8 to proceed normally.