### PR TITLE
Add host policy field

### DIFF
--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -287,7 +287,7 @@ message ModelInstanceGroup
   //@@     for instance, KIND_CPU is "cpu", KIND_MODEL is "model" and
   //@@     KIND_GPU is "gpu_<gpu_id>".
   //@@
-  string host_policy = 8;
+  string host_policy = 9;
 }
 
 //@@

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -279,6 +279,14 @@ message ModelInstanceGroup
   //@@     not be added to the scheduler. Default value is false.
   //@@
   bool passive = 7;
+
+  //@@  .. cpp:var:: int32 numa_id
+  //@@
+  //@@     The id used to associate with NUMA related features for the instance
+  //@@     group. For KIND_GPU, the default value will be the same as the GPU id
+  //@@     of the instance. For other kinds, the default value is 0.
+  //@@
+  int32 numa_id = 8;
 }
 
 //@@

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -283,8 +283,9 @@ message ModelInstanceGroup
   //@@  .. cpp:var:: int32 numa_id
   //@@
   //@@     The id used to associate with NUMA related features for the instance
-  //@@     group. For KIND_GPU, the default value will be the same as the GPU id
-  //@@     of the instance. For other kinds, the default value is 0.
+  //@@     group. For KIND_GPU, this field will be ignored and the value will be
+  //@@     set to the GPU id of the instance.
+  //@@     For other kinds, the default value is 0.
   //@@
   int32 numa_id = 8;
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -284,7 +284,8 @@ message ModelInstanceGroup
   //@@
   //@@     The host policy name that the instance to be associated with.
   //@@     The default value is set to reflect the device kind of the instance,
-  //@@     for instance, KIND_CPU is "cpu" and KIND_GPU is "gpu_<gpu_id>".
+  //@@     for instance, KIND_CPU is "cpu", KIND_MODEL is "model" and
+  //@@     KIND_GPU is "gpu_<gpu_id>".
   //@@
   string host_policy = 8;
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -280,14 +280,13 @@ message ModelInstanceGroup
   //@@
   bool passive = 7;
 
-  //@@  .. cpp:var:: int32 numa_id
+  //@@  .. cpp:var:: string host_policy
   //@@
-  //@@     The id used to associate with NUMA related features for the instance
-  //@@     group. For KIND_GPU, this field will be ignored and the value will be
-  //@@     set to the GPU id of the instance.
-  //@@     For other kinds, the default value is 0.
+  //@@     The host policy name that the instance to be associated with.
+  //@@     The default value is set to reflect the device kind of the instance,
+  //@@     for instance, KIND_CPU is "cpu" and KIND_GPU is "gpu_<gpu_id>".
   //@@
-  int32 numa_id = 8;
+  string host_policy = 8;
 }
 
 //@@


### PR DESCRIPTION
Note that the numa id for GPU instance will always be the same as the gpu id, this is because in proto3 there is no way to tell if a primitive type is set explicitly or the default value is used, i.e. 0 can either be the user sets the id to 0 or the user doesn't set the value. Which will be confusing for GPU instance because the default behavior for GPU instance is that instances on different GPU device will be assigned to different numa id, but we can't differentiate the meaning of 0 here.

If we really want to be able to overwrite numa id for GPU instances, a work around is to wrap the numa id in a protobuf message so we will check if the message is specified to determine if the numa id is set explicitly.