### PR TITLE
Add git pre-commit script to use with format.py

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -29,6 +29,9 @@
 #
 # Git pre-commit hook for Triton related projects
 #
+# To install this hook for a project, copy "pre-commit" and "format.py" into
+# ".git/hooks/" directory of the project
+#
 ###############################################################################
 
 ###############################################################################

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+###############################################################################
+#
+# Git pre-commit hook for Triton related projects
+#
+###############################################################################
+
+###############################################################################
+#
+# Run formatter script
+#
+###############################################################################
+
+# Repo root
+GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
+
+PYTHON_CMD=python3
+FORMATTER_PY=${GIT_REPO_ROOT}/.git/hooks/format.py
+
+CHANGED_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" { print $2}')"
+
+echo "Running Python auto-format..."
+for CHANGED_FILE in $CHANGED_FILES;
+do
+    ${PYTHON_CMD} ${FORMATTER_PY} ${GIT_REPO_ROOT}/${CHANGED_FILE}
+    git add ${GIT_REPO_ROOT}/${CHANGED_FILE}
+done


### PR DESCRIPTION
Integrating the formatter into git workflow is a nice thing to have. To use that, just copying `pre-commit` and `format.py` into `.git/hooks/` of the desired repo