### PR TITLE
Fix pessimizing move in function return

### DIFF
--- a/src/table_printer.cc
+++ b/src/table_printer.cc
@@ -214,7 +214,7 @@ TablePrinter::PrintTable()
 
   AddRowDivider(table);
 
-  return std::move(table.str());
+  return table.str();
 }
 
 // TablePrinter will take the ownership of `headers`.


### PR DESCRIPTION
* allows the compiler to do copy elision

* allows compiling on newer clang versions with -Werror