### PR TITLE
Refactor cmake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
 #
 # Async Work Queue
 #
@@ -119,7 +121,12 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(triton-common-async-work-queue PRIVATE common-compile-settings)
+target_link_libraries(triton-common-async-work-queue
+  PUBLIC
+    Threads::Threads
+  PRIVATE
+    common-compile-settings
+)
 
 #
 # JSON utilities

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dependencies.
 $ apt-get install rapidjson-dev
 ```
 
-Use cmake 3.14 or later to build and install in a local directory.
+Use cmake 3.17 or later to build and install in a local directory.
 
 ```
 $ mkdir build

--- a/cmake/TritonCommonConfig.cmake.in
+++ b/cmake/TritonCommonConfig.cmake.in
@@ -24,17 +24,20 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include(CMakeFindDependencyMacro)
+@PACKAGE_INIT@
 
-get_filename_component(
-  TRITONCOMMON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH
-)
+set_and_check(TRITONCOMMON_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 list(APPEND CMAKE_MODULE_PATH ${TRITONCOMMON_CMAKE_DIR})
 
 if(NOT TARGET TritonCommon::triton-common-json)
   include("${TRITONCOMMON_CMAKE_DIR}/TritonCommonTargets.cmake")
 endif()
+
+check_required_components(triton-common-json
+  triton-common-sync-queue
+  triton-common-async-work-queue
+)
 
 set(TRITONCOMMON_LIBRARIES 
   TritonCommon::triton-common-json

--- a/cmake/TritonCommonConfig.cmake.in
+++ b/cmake/TritonCommonConfig.cmake.in
@@ -30,6 +30,9 @@ set_and_check(TRITONCOMMON_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 list(APPEND CMAKE_MODULE_PATH ${TRITONCOMMON_CMAKE_DIR})
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 if(NOT TARGET TritonCommon::triton-common-json)
   include("${TRITONCOMMON_CMAKE_DIR}/TritonCommonTargets.cmake")
 endif()

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -26,7 +26,7 @@
 
 cmake_minimum_required (VERSION 3.18)
 
- set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
+set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
 find_package(Protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${Protobuf_VERSION}")
 include_directories(${Protobuf_INCLUDE_DIRS})


### PR DESCRIPTION
Hello, *!

I've done the following things for the cmake build of this project:

* remove extra whitespace
* use the @PACKAGE_INIT@ variable to add functionality to the
config.cmake - see: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html
* remove unused find_dependency cmake include - wasn't used, but in fact it should be - and it should search for RapidJSON which is a public dependency - the problem is the version usually installed on ubuntu has an old cmake config file which does not expose targets. this makes it hard for the triton-common project to work correctly when installed
* update minimum cmake version in readme (was 3.14 when the project needs at least 3.17 - from the cml)

There are some other things that can be done to improve the build system: adding a custom `FindRapidJSON.cmake` module which would get installed alongside `triton-common`. This would allow `triton-common` to be used as a package (installed). While that may not be interesting right now, it may become more of a thing once package managers are better.

Would this be interesting?
Thanks!

Edit1: found out `find_dependency` could be useful, for Threads!