### PR TITLE
Fix const&& won't allow std::move in AddTask

### DIFF
--- a/include/triton/common/async_work_queue.h
+++ b/include/triton/common/async_work_queue.h
@@ -51,7 +51,7 @@ class AsyncWorkQueue {
 
   // Add a 'task' to the queue. The function will take ownership of 'task'.
   // Therefore std::move should be used when calling AddTask.
-  static Error AddTask(const std::function<void(void)>&& task);
+  static Error AddTask(std::function<void(void)>&& task);
 
  protected:
   static void Reset();

--- a/src/async_work_queue.cc
+++ b/src/async_work_queue.cc
@@ -84,7 +84,7 @@ AsyncWorkQueue::WorkerCount()
 }
 
 Error
-AsyncWorkQueue::AddTask(const std::function<void(void)>&& task)
+AsyncWorkQueue::AddTask(std::function<void(void)>&& task)
 {
   if (GetSingleton()->worker_threads_.size() == 0) {
     return Error(


### PR DESCRIPTION
Hi!

* even though there was a std::move in `AddTask`, it would do nothing
looking at the callstack we can see it actually calls `Put(const&)` all
the time, see this similar example: https://godbolt.org/z/d9xqKT6jx

Does it really help for it to be const? Is there a reason a copy is `wanted` for those `std::functions`? The semantics I know for `const&&` revolve around `users can't use lvalues, but we'll still copy the value they pass`.

Maybe I missed something tho so please let me know!
Thanks