### PR TITLE
WIP: Add support for I/O tensor structure to model config

### DIFF
--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1739,24 +1739,19 @@ message TensorStructure
 {
   message ListStructure
   {
-    repeated TensorStructure list = 1;
+    repeated TensorStructure item = 1;
   }
 
-  message TupleStructure
+  message ReadOnlyListStructure
   {
-    repeated TensorStructure tuple = 1;
+    repeated TensorStructure item = 1;
   }
 
-  message MapStructure
-  {
-    map<string, TensorStructure> dict = 1;
-  }
-
-  oneof struct_kind 
+  oneof struct_kind
   {
     ListStructure list = 1;
-    TupleStructure tuple = 2;
-    MapStructure dict = 3;
+    ReadOnlyListStructure read_only_list = 2;
+    map<string, TensorStructure> dict = 3;
     string tensor_name = 4;
   }
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1747,11 +1747,20 @@ message TensorStructure
     repeated TensorStructure item = 1;
   }
 
+  message MapStructure {
+    message MapItem {
+      string key = 1;
+      TensorStructure value = 2;
+    }
+
+    repeated MapItem item = 1;
+  }
+
   oneof struct_kind
   {
     ListStructure list = 1;
     ReadOnlyListStructure read_only_list = 2;
-    map<string, TensorStructure> dict = 3;
+    MapStructure dict = 3;
     string tensor_name = 4;
   }
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -1734,6 +1734,16 @@ message ModelResponseCache
   bool enable = 1;
 }
 
+message TensorStructure {
+  oneof kind_choice 
+  {
+    map<string, TensorStructure> dict = 1;
+    repeated TensorStructure list = 2;
+    repeated TensorStructure read_only_list = 3;
+    string tensor_name = 4;
+  }
+}
+
 //@@
 //@@.. cpp:var:: message ModelConfig
 //@@
@@ -1936,4 +1946,8 @@ message ModelConfig
   //@@     model.
   //@@
   ModelResponseCache response_cache = 24;
+
+  repeated TensorStructure input_tensors_structure = 25;
+
+  repeated TensorStructure output_tensors_structure = 26;
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1734,10 +1734,6 @@ message ModelResponseCache
   bool enable = 1;
 }
 
-//@@message Tensor {
-  //@@string tensor_name = 1;
-//@@}
-
 message ListStruct 
 {
   repeated TensorStructure list = 1;
@@ -1750,8 +1746,6 @@ message TupleStruct
 message MapStruct 
 {
   map<string, TensorStructure> dict = 1;
-  //@@string key = 1;
-  //@@TensorStruct value = 2;
 }
 
 message TensorStructure {

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1734,28 +1734,31 @@ message ModelResponseCache
   bool enable = 1;
 }
 
-message ListStruct 
-{
-  repeated TensorStructure list = 1;
-}
 
-message TupleStruct 
+message TensorStructure 
 {
-  repeated TensorStructure tuple = 1;
-}
-message MapStruct 
-{
-  map<string, TensorStructure> dict = 1;
-}
+  message ListStructure
+  {
+    repeated TensorStructure list = 1;
+  }
 
-message TensorStructure {
+  message TupleStructure
+  {
+    repeated TensorStructure tuple = 1;
+  }
+
+  message MapStructure
+  {
+    map<string, TensorStructure> dict = 1;
+  }
+
   oneof struct_kind 
   {
-    ListStruct list = 1;
-    TupleStruct tuple = 2;
-    MapStruct dict = 3;
+    ListStructure list = 1;
+    TupleStructure tuple = 2;
+    MapStructure dict = 3;
     string tensor_name = 4;
-  } 
+  }
 }
 
 //@@

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1734,14 +1734,34 @@ message ModelResponseCache
   bool enable = 1;
 }
 
+//@@message Tensor {
+  //@@string tensor_name = 1;
+//@@}
+
+message ListStruct 
+{
+  repeated TensorStructure list = 1;
+}
+
+message TupleStruct 
+{
+  repeated TensorStructure tuple = 1;
+}
+message MapStruct 
+{
+  map<string, TensorStructure> dict = 1;
+  //@@string key = 1;
+  //@@TensorStruct value = 2;
+}
+
 message TensorStructure {
-  oneof kind_choice 
+  oneof struct_kind 
   {
-    map<string, TensorStructure> dict = 1;
-    repeated TensorStructure list = 2;
-    repeated TensorStructure read_only_list = 3;
+    ListStruct list = 1;
+    TupleStruct tuple = 2;
+    MapStruct dict = 3;
     string tensor_name = 4;
-  }
+  } 
 }
 
 //@@


### PR DESCRIPTION
- Will add descriptions once finalized

Reasons for revised protobuf design:
1. map cannot be a repeated field
2. oneof cannot contain repeated fields