### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ project(tritoncommon LANGUAGES C CXX)
 # dependencies, so those parts of the build must be enabled
 # explicitly.
 option(TRITON_COMMON_ENABLE_PROTOBUF "Build protobuf artifacts" OFF)
+option(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON "Build protobuf artifacts for python" ON)
 option(TRITON_COMMON_ENABLE_GRPC "Build grpc artifacts" OFF)
 option(TRITON_COMMON_ENABLE_JSON "Build json-related libs" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,6 @@ install(
     triton-common-error
     triton-common-logging
     triton-common-sync-queue
-    triton-common-json
     triton-common-table-printer
     common-compile-settings
   EXPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,12 @@ project(tritoncommon LANGUAGES C CXX)
 # explicitly.
 option(TRITON_COMMON_ENABLE_PROTOBUF "Build protobuf artifacts" OFF)
 option(TRITON_COMMON_ENABLE_GRPC "Build grpc artifacts" OFF)
+option(TRITON_COMMON_ENABLE_JSON "Build json-related libs" ON)
 
-find_package(RapidJSON CONFIG REQUIRED)
-message(STATUS "RapidJSON found. Headers: ${RAPIDJSON_INCLUDE_DIRS}")
+if(TRITON_COMMON_ENABLE_JSON)
+  find_package(RapidJSON CONFIG REQUIRED)
+  message(STATUS "RapidJSON found. Headers: ${RAPIDJSON_INCLUDE_DIRS}")
+endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
@@ -162,22 +165,24 @@ target_link_libraries(triton-common-async-work-queue
 #
 # JSON utilities
 #
-add_library(
-  triton-common-json INTERFACE
-)
+if(TRITON_COMMON_ENABLE_JSON)
+  add_library(
+    triton-common-json INTERFACE
+  )
 
-add_library(
-  TritonCommon::triton-common-json ALIAS triton-common-json
-)
+  add_library(
+    TritonCommon::triton-common-json ALIAS triton-common-json
+  )
 
-target_include_directories(
-  triton-common-json
-  INTERFACE
-    $<INSTALL_INTERFACE:include>
-    $<INSTALL_INTERFACE:${RAPIDJSON_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${RAPIDJSON_INCLUDE_DIRS}>
-)
+  target_include_directories(
+    triton-common-json
+    INTERFACE
+      $<INSTALL_INTERFACE:include>
+      $<INSTALL_INTERFACE:${RAPIDJSON_INCLUDE_DIRS}>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${RAPIDJSON_INCLUDE_DIRS}>
+  )
+endif()
 
 #
 # Table Printer
@@ -263,6 +268,17 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(TRITON_COMMON_ENABLE_JSON)
+  install(
+    TARGETS
+      triton-common-json
+    EXPORT
+      triton-common-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+endif()
 
 if(${TRITON_COMMON_ENABLE_GRPC} OR ${TRITON_COMMON_ENABLE_PROTOBUF})
   install(

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -43,7 +43,9 @@ endif()
 if(${TRITON_COMMON_ENABLE_PROTOBUF})
   file(GLOB proto-srcs *.proto)
   protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${proto-srcs})
-  protobuf_generate_python(PROTO_PY ${proto-srcs})
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    protobuf_generate_python(PROTO_PY ${proto-srcs})
+  endif()
 
   set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
   if(${TRITON_COMMON_ENABLE_GRPC})
@@ -74,7 +76,9 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF})
       POSITION_INDEPENDENT_CODE ON
   )
 
-  add_custom_target(proto-py-library DEPENDS ${PROTO_PY})
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    add_custom_target(proto-py-library DEPENDS ${PROTO_PY})
+  endif()
 
   install(
     FILES
@@ -91,7 +95,9 @@ if(${TRITON_COMMON_ENABLE_GRPC})
   get_filename_component(grpc_service_proto_dir "${grpc_service_proto_abspath}" PATH)
   set(GRPC_SRCS "grpc_service.grpc.pb.cc")
   set(GRPC_HDRS "grpc_service.grpc.pb.h")
-  set(GRPC_PY "grpc_service.grpc.py")
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    set(GRPC_PY "grpc_service.grpc.py")
+  endif()
 
   add_custom_command(
     OUTPUT "${GRPC_SRCS}" "${GRPC_HDRS}"
@@ -105,17 +111,19 @@ if(${TRITON_COMMON_ENABLE_GRPC})
     DEPENDS "grpc_service.proto" proto-library
   )
 
-  find_package(Python REQUIRED COMPONENTS Interpreter)
-  add_custom_command(
-    OUTPUT "${GRPC_PY}"
-    COMMAND ${Python_EXECUTABLE}
-    ARGS
-      -m grpc_tools.protoc
-      -I "${grpc_service_proto_dir}"
-      --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
-      "grpc_service.proto"
-    DEPENDS "grpc_service.proto" proto-library
-  )
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    add_custom_command(
+      OUTPUT "${GRPC_PY}"
+      COMMAND ${Python_EXECUTABLE}
+      ARGS
+        -m grpc_tools.protoc
+        -I "${grpc_service_proto_dir}"
+        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
+        "grpc_service.proto"
+      DEPENDS "grpc_service.proto" proto-library
+    )
+  endif()
 
   add_library(
     grpc-service-library EXCLUDE_FROM_ALL OBJECT
@@ -141,7 +149,9 @@ if(${TRITON_COMMON_ENABLE_GRPC})
       POSITION_INDEPENDENT_CODE ON
   )
 
-  add_custom_target(grpc-service-py-library DEPENDS ${GRPC_PY})
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    add_custom_target(grpc-service-py-library DEPENDS ${GRPC_PY})
+  endif()
 
   install(
     FILES


### PR DESCRIPTION
This PR adds a few CMake options to help address https://github.com/triton-inference-server/server/issues/3141:
* `TRITON_COMMON_ENABLE_PROTOBUF_PYTHON`, on by default. If turned off, will avoid building python artifacts when just c++ artifacts are needed.
* `TRITON_COMMON_ENABLE_JSON`, on by default. If turned off, will avoid building json-related libraries, which are not always needed and involve additional dependencies.

This PR goes with https://github.com/triton-inference-server/client/pull/95.