### PR TITLE
Move model_config to common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,10 @@ set_target_properties(
 if(${TRITON_COMMON_ENABLE_PROTOBUF} OR ${TRITON_COMMON_ENABLE_GRPC})
   add_subdirectory(protobuf)
 
+  set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
+  find_package(Protobuf CONFIG REQUIRED)
+  message(STATUS "Using protobuf ${Protobuf_VERSION}")
+
   #
   # Model Config (depends on protobuf & generated .pb.h file)
   #
@@ -262,6 +266,7 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF} OR ${TRITON_COMMON_ENABLE_GRPC})
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/src
+      ${Protobuf_INCLUDE_DIRS}
   )
 
   target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF} OR ${TRITON_COMMON_ENABLE_GRPC})
   #
   add_library(
     triton-common-model-config
-    src/model-config.cc
+    src/model_config.cc
     )
 
   add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,9 +202,33 @@ target_include_directories(
 
 target_link_libraries(triton-common-table-printer PRIVATE common-compile-settings)
 
+#
+# Model Config
+#
+add_library(
+  triton-common-model-config
+  src/model-config.cc
+  )
+
+add_library(
+  TritonCommon::triton-common-model-config ALIAS triton-common-model-config
+)
+
+target_include_directories(
+  triton-common-model-config
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(triton-common-model-config PRIVATE common-compile-settings)
+
 set_target_properties(
   triton-common-async-work-queue
   triton-common-error
+  triton-common-model-config
   triton-common-logging
   triton-common-table-printer
   PROPERTIES
@@ -222,6 +246,12 @@ set_target_properties(
   triton-common-error
   PROPERTIES
     OUTPUT_NAME tritoncommonerror
+)
+
+set_target_properties(
+  triton-common-model-config
+  PROPERTIES
+    OUTPUT_NAME tritoncommonmodelconfig
 )
 
 set_target_properties(
@@ -253,6 +283,7 @@ install(
   TARGETS
     triton-common-async-work-queue
     triton-common-error
+    triton-common-model-config
     triton-common-logging
     triton-common-sync-queue
     triton-common-json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,33 +202,10 @@ target_include_directories(
 
 target_link_libraries(triton-common-table-printer PRIVATE common-compile-settings)
 
-#
-# Model Config
-#
-add_library(
-  triton-common-model-config
-  src/model-config.cc
-  )
-
-add_library(
-  TritonCommon::triton-common-model-config ALIAS triton-common-model-config
-)
-
-target_include_directories(
-  triton-common-model-config
-  PUBLIC
-    $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-)
-
-target_link_libraries(triton-common-model-config PRIVATE common-compile-settings)
 
 set_target_properties(
   triton-common-async-work-queue
   triton-common-error
-  triton-common-model-config
   triton-common-logging
   triton-common-table-printer
   PROPERTIES
@@ -249,12 +226,6 @@ set_target_properties(
 )
 
 set_target_properties(
-  triton-common-model-config
-  PROPERTIES
-    OUTPUT_NAME tritoncommonmodelconfig
-)
-
-set_target_properties(
   triton-common-logging
   PROPERTIES
     OUTPUT_NAME tritoncommonlogging
@@ -271,6 +242,44 @@ set_target_properties(
 #
 if(${TRITON_COMMON_ENABLE_PROTOBUF} OR ${TRITON_COMMON_ENABLE_GRPC})
   add_subdirectory(protobuf)
+
+  #
+  # Model Config (depends on protobuf & generated .pb.h file)
+  #
+  add_library(
+    triton-common-model-config
+    src/model-config.cc
+    )
+
+  add_library(
+    TritonCommon::triton-common-model-config ALIAS triton-common-model-config
+  )
+
+  target_include_directories(
+    triton-common-model-config
+    PUBLIC
+      $<INSTALL_INTERFACE:include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+
+  target_link_libraries(
+    triton-common-model-config
+    PRIVATE
+      common-compile-settings
+      protobuf::libprotobuf
+      proto-library
+  )
+
+  set_target_properties(
+    triton-common-model-config
+    PROPERTIES
+      WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+      POSITION_INDEPENDENT_CODE ON
+      OUTPUT_NAME tritoncommonmodelconfig
+  )
+
 endif()
 
 #
@@ -283,7 +292,6 @@ install(
   TARGETS
     triton-common-async-work-queue
     triton-common-error
-    triton-common-model-config
     triton-common-logging
     triton-common-sync-queue
     triton-common-json
@@ -299,6 +307,7 @@ if(${TRITON_COMMON_ENABLE_GRPC} OR ${TRITON_COMMON_ENABLE_PROTOBUF})
   install(
     TARGETS
       proto-library
+      triton-common-model-config
 #      proto-py-library
     EXPORT
       triton-common-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,6 @@ target_include_directories(
 
 target_link_libraries(triton-common-table-printer PRIVATE common-compile-settings)
 
-
 set_target_properties(
   triton-common-async-work-queue
   triton-common-error

--- a/include/triton/common/model_config.h
+++ b/include/triton/common/model_config.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/common/model_config.h
+++ b/include/triton/common/model_config.h
@@ -241,4 +241,4 @@ inference::DataType ProtocolStringToDataType(const std::string& dtype);
 /// \return The data type.
 inference::DataType ProtocolStringToDataType(const char* dtype, size_t len);
 
-}}  // namespace triton::core
+}}  // namespace triton::common

--- a/include/triton/common/model_config.h
+++ b/include/triton/common/model_config.h
@@ -1,0 +1,244 @@
+// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <google/protobuf/any.pb.h>
+#include <stdint.h>
+#include "model_config.pb.h"
+
+namespace triton { namespace core {
+
+/// The type for a repeated dims field (used for shape).
+using DimsList = ::google::protobuf::RepeatedField<::google::protobuf::int64>;
+
+/// The type for the metric_tags map.
+using MetricTagsMap = ::google::protobuf::Map<
+    ::google::protobuf::string, ::google::protobuf::string>;
+
+// Map from a host policy name to <setting, value> map of cmdline
+// settings for the host policy.
+using HostPolicyCmdlineConfig = std::map<std::string, std::string>;
+using HostPolicyCmdlineConfigMap =
+    std::unordered_map<std::string, HostPolicyCmdlineConfig>;
+
+// Map from backend name to list of setting=value pairs of cmdline
+// settings for the backend.
+using BackendCmdlineConfig = std::vector<std::pair<std::string, std::string>>;
+using BackendCmdlineConfigMap =
+    std::unordered_map<std::string, BackendCmdlineConfig>;
+
+/// The value for a dimension in a shape that indicates that that
+/// dimension can take on any size.
+constexpr int WILDCARD_DIM = -1;
+
+constexpr int SCHEDULER_DEFAULT_NICE = 5;
+
+/// Enumeration for the different platform types.
+enum Platform {
+  PLATFORM_UNKNOWN = 0,
+  PLATFORM_TENSORRT_PLAN = 1,
+  PLATFORM_TENSORFLOW_GRAPHDEF = 2,
+  PLATFORM_TENSORFLOW_SAVEDMODEL = 3,
+  PLATFORM_ENSEMBLE = 4,
+  PLATFORM_ONNXRUNTIME_ONNX = 5,
+  PLATFORM_PYTORCH_LIBTORCH = 6
+};
+
+/// Get the number of elements in a shape.
+/// \param dims The shape.
+/// \return The number of elements, or -1 if the number of elements
+/// cannot be determined because the shape contains one or more
+/// wilcard dimensions.
+int64_t GetElementCount(const DimsList& dims);
+
+/// Get the number of elements in a shape.
+/// \param dims The shape.
+/// \return The number of elements, or -1 if the number of elements
+/// cannot be determined because the shape contains one or more
+/// wilcard dimensions.
+int64_t GetElementCount(const std::vector<int64_t>& dims);
+
+/// Get the number of elements in the shape of a model input.
+/// \param mio The model input.
+/// \return The number of elements, or -1 if the number of elements
+/// cannot be determined because the shape contains one or more
+/// wilcard dimensions.
+int64_t GetElementCount(const inference::ModelInput& mio);
+
+/// Get the number of elements in the shape of a model output.
+/// \param mio The model output.
+/// \return The number of elements, or -1 if the number of elements
+/// cannot be determined because the shape contains one or more
+/// wilcard dimensions.
+int64_t GetElementCount(const inference::ModelOutput& mio);
+
+/// Are values of a datatype fixed-size, or variable-sized.
+/// \param dtype The data-type.
+/// \return True if datatype values are fixed-sized, false if
+/// variable-sized.
+bool IsFixedSizeDataType(const inference::DataType dtype);
+
+/// Get the size of objects of a given datatype in bytes.
+/// \param dtype The data-type.
+/// \return The size, in bytes, of objects of the datatype, or 0 if
+/// size cannot be determine (for example, values of type TYPE_STRING
+/// have variable length and so size cannot be determine just from the
+/// type).
+size_t GetDataTypeByteSize(const inference::DataType dtype);
+
+/// Get the size, in bytes, of a tensor based on datatype and
+/// shape.
+/// \param dtype The data-type.
+/// \param dims The shape.
+/// \return The size, in bytes, of the corresponding tensor, or -1 if
+/// unable to determine the size.
+int64_t GetByteSize(const inference::DataType& dtype, const DimsList& dims);
+
+/// Get the size, in bytes, of a tensor based on datatype and
+/// shape.
+/// \param dtype The data-type.
+/// \param dims The shape.
+/// \return The size, in bytes, of the corresponding tensor, or -1 if
+/// unable to determine the size.
+int64_t GetByteSize(
+    const inference::DataType& dtype, const std::vector<int64_t>& dims);
+
+/// Get the size, in bytes, of a tensor based on batch-size, datatype
+/// and shape. A tensor that has empty shape [] and non-zero
+/// batch-size is sized as a tensor with shape [ batch-size ].
+/// \param batch_size The batch-size. May be 0 to indicate no
+/// batching.
+/// \param dtype The data-type.
+/// \param dims The shape.
+/// \return The size, in bytes, of the corresponding tensor, or -1 if
+/// unable to determine the size.
+int64_t GetByteSize(
+    const int batch_size, const inference::DataType& dtype,
+    const DimsList& dims);
+
+/// Get the size, in bytes, of a tensor based on batch-size, datatype
+/// and shape. A tensor that has empty shape [] and non-zero
+/// batch-size is sized as a tensor with shape [ batch-size ].
+/// \param batch_size The batch-size. May be 0 to indicate no
+/// batching.
+/// \param dtype The data-type.
+/// \param dims The shape.
+/// \return The size, in bytes, of the corresponding tensor, or -1 if
+/// unable to determine the size.
+int64_t GetByteSize(
+    const int batch_size, const inference::DataType& dtype,
+    const std::vector<int64_t>& dims);
+
+/// Get the size, in bytes, of a tensor based on ModelInput.
+/// \param mio The ModelInput protobuf.
+/// \return The size, in bytes, of the corresponding tensor, or -1 if
+/// unable to determine the size.
+int64_t GetByteSize(const inference::ModelInput& mio);
+
+/// Get the size, in bytes, of a tensor based on ModelOutput.
+/// \param mio The ModelOutput protobuf.
+/// \return The size, in bytes, of the corresponding tensor, or -1 if
+/// unable to determine the size.
+int64_t GetByteSize(const inference::ModelOutput& mio);
+
+/// Get the CPU thread nice level associate with a model
+/// configuration's priority.
+/// \param config The model configuration.
+/// \return The nice level.
+int GetCpuNiceLevel(const inference::ModelConfig& config);
+
+/// Compare two model configuration shapes for equality. Wildcard
+/// dimensions (that is, dimensions with size WILDCARD_DIM) are
+/// compared literally so that to be equal the two shapes must both
+/// specify WILDCARD_DIM in the same dimensions.
+/// \params dims0 The first shape.
+/// \params dims1 The second shape.
+/// \return True if the shapes are equal, false if not equal.
+bool CompareDims(const DimsList& dims0, const DimsList& dims1);
+
+/// Compare two model configuration shapes for equality. Wildcard
+/// dimensions (that is, dimensions with size WILDCARD_DIM) are
+/// compared literally so that to be equal the two shapes must both
+/// specify WILDCARD_DIM in the same dimensions.
+/// \params dims0 The first shape.
+/// \params dims1 The second shape.
+/// \return True if the shapes are equal, false if not equal.
+bool CompareDims(
+    const std::vector<int64_t>& dims0, const std::vector<int64_t>& dims1);
+
+/// Compare two model configuration shapes for equality. Wildcard
+/// dimensions (that is, dimensions with size WILDCARD_DIM) are
+/// allowed to match with any value. So, a dimension in one shape
+/// specified as WILDCARD_DIM will always match the same dimension in
+/// the other shape.
+/// \params dims0 The first shape.
+/// \params dims1 The second shape.
+/// \return True if the shapes are equal, false if not equal.
+bool CompareDimsWithWildcard(const DimsList& dims0, const DimsList& dims1);
+
+/// Compare two model configuration shapes for equality. Wildcard
+/// dimensions (that is, dimensions with size WILDCARD_DIM) are
+/// allowed to match with any value. So, a dimension in one shape
+/// specified as WILDCARD_DIM will always match the same dimension in
+/// the other shape.
+/// \params dims0 The first shape.
+/// \params dims1 The second shape.
+/// \return True if the shapes are equal, false if not equal.
+bool CompareDimsWithWildcard(
+    const DimsList& dims0, const std::vector<int64_t>& dims1);
+
+/// Convert a DimsList to string representation.
+/// \param dims The DimsList to be converted.
+/// \return String representation of the DimsList in pattern
+/// "[d0,d1,...,dn]"
+std::string DimsListToString(const DimsList& dims);
+
+/// Convert a vector representing a shape to string representation.
+/// \param dims The vector of dimensions to be converted.
+/// \return String representation of the vector in pattern
+/// "[d0,d1,...,dn]"
+std::string DimsListToString(
+    const std::vector<int64_t>& dims, const int start_idx = 0);
+
+/// Get the server protocol string representation of a datatype.
+/// \param dtype The data type.
+/// \return The string representation.
+const char* DataTypeToProtocolString(const inference::DataType dtype);
+
+/// Get the datatype corresponding to a server protocol string
+/// representation of a datatype.
+/// \param dtype string representation.
+/// \return The data type.
+inference::DataType ProtocolStringToDataType(const std::string& dtype);
+
+/// Get the datatype corresponding to a server protocol string
+/// representation of a datatype.
+/// \param dtype Pointer to string.
+/// \param len Length of the string.
+/// \return The data type.
+inference::DataType ProtocolStringToDataType(const char* dtype, size_t len);
+
+}}  // namespace triton::core

--- a/include/triton/common/model_config.h
+++ b/include/triton/common/model_config.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include "model_config.pb.h"
 
-namespace triton { namespace core {
+namespace triton { namespace common {
 
 /// The type for a repeated dims field (used for shape).
 using DimsList = ::google::protobuf::RepeatedField<::google::protobuf::int64>;

--- a/src/model_config.cc
+++ b/src/model_config.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/model_config.cc
+++ b/src/model_config.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/model_config.cc
+++ b/src/model_config.cc
@@ -26,7 +26,7 @@
 
 #include "triton/common/model_config.h"
 
-namespace triton { namespace core {
+namespace triton { namespace common {
 
 bool
 IsFixedSizeDataType(const inference::DataType dtype)

--- a/src/model_config.cc
+++ b/src/model_config.cc
@@ -426,4 +426,4 @@ ProtocolStringToDataType(const char* dtype, size_t len)
   return inference::DataType::TYPE_INVALID;
 }
 
-}}  // namespace triton::core
+}}  // namespace triton::common

--- a/src/model_config.cc
+++ b/src/model_config.cc
@@ -1,0 +1,429 @@
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "triton/common/model_config.h"
+
+namespace triton { namespace core {
+
+bool
+IsFixedSizeDataType(const inference::DataType dtype)
+{
+  return dtype != inference::DataType::TYPE_STRING;
+}
+
+size_t
+GetDataTypeByteSize(const inference::DataType dtype)
+{
+  switch (dtype) {
+    case inference::DataType::TYPE_BOOL:
+      return 1;
+    case inference::DataType::TYPE_UINT8:
+      return 1;
+    case inference::DataType::TYPE_UINT16:
+      return 2;
+    case inference::DataType::TYPE_UINT32:
+      return 4;
+    case inference::DataType::TYPE_UINT64:
+      return 8;
+    case inference::DataType::TYPE_INT8:
+      return 1;
+    case inference::DataType::TYPE_INT16:
+      return 2;
+    case inference::DataType::TYPE_INT32:
+      return 4;
+    case inference::DataType::TYPE_INT64:
+      return 8;
+    case inference::DataType::TYPE_FP16:
+      return 2;
+    case inference::DataType::TYPE_FP32:
+      return 4;
+    case inference::DataType::TYPE_FP64:
+      return 8;
+    case inference::DataType::TYPE_STRING:
+      return 0;
+    default:
+      break;
+  }
+
+  return 0;
+}
+
+int64_t
+GetElementCount(const DimsList& dims)
+{
+  bool first = true;
+  int64_t cnt = 0;
+  for (auto dim : dims) {
+    if (dim == WILDCARD_DIM) {
+      return -1;
+    }
+
+    if (first) {
+      cnt = dim;
+      first = false;
+    } else {
+      cnt *= dim;
+    }
+  }
+
+  return cnt;
+}
+
+int64_t
+GetElementCount(const std::vector<int64_t>& dims)
+{
+  bool first = true;
+  int64_t cnt = 0;
+  for (auto dim : dims) {
+    if (dim == WILDCARD_DIM) {
+      return -1;
+    }
+
+    if (first) {
+      cnt = dim;
+      first = false;
+    } else {
+      cnt *= dim;
+    }
+  }
+
+  return cnt;
+}
+
+int64_t
+GetElementCount(const inference::ModelInput& mio)
+{
+  return GetElementCount(mio.dims());
+}
+
+int64_t
+GetElementCount(const inference::ModelOutput& mio)
+{
+  return GetElementCount(mio.dims());
+}
+
+int64_t
+GetByteSize(const inference::DataType& dtype, const DimsList& dims)
+{
+  size_t dt_size = GetDataTypeByteSize(dtype);
+  if (dt_size == 0) {
+    return -1;
+  }
+
+  int64_t cnt = GetElementCount(dims);
+  if (cnt == -1) {
+    return -1;
+  }
+
+  return cnt * dt_size;
+}
+
+int64_t
+GetByteSize(const inference::DataType& dtype, const std::vector<int64_t>& dims)
+{
+  size_t dt_size = GetDataTypeByteSize(dtype);
+  if (dt_size == 0) {
+    return -1;
+  }
+
+  int64_t cnt = GetElementCount(dims);
+  if (cnt == -1) {
+    return -1;
+  }
+
+  return cnt * dt_size;
+}
+
+int64_t
+GetByteSize(
+    const int batch_size, const inference::DataType& dtype,
+    const DimsList& dims)
+{
+  if (dims.size() == 0) {
+    return batch_size * GetDataTypeByteSize(dtype);
+  }
+
+  int64_t bs = GetByteSize(dtype, dims);
+  if (bs == -1) {
+    return -1;
+  }
+
+  return std::max(1, batch_size) * bs;
+}
+
+int64_t
+GetByteSize(
+    const int batch_size, const inference::DataType& dtype,
+    const std::vector<int64_t>& dims)
+{
+  if (dims.size() == 0) {
+    return batch_size * GetDataTypeByteSize(dtype);
+  }
+
+  int64_t bs = GetByteSize(dtype, dims);
+  if (bs == -1) {
+    return -1;
+  }
+
+  return std::max(1, batch_size) * bs;
+}
+
+int64_t
+GetByteSize(const inference::ModelInput& mio)
+{
+  return GetByteSize(mio.data_type(), mio.dims());
+}
+
+int64_t
+GetByteSize(const inference::ModelOutput& mio)
+{
+  return GetByteSize(mio.data_type(), mio.dims());
+}
+
+int
+GetCpuNiceLevel(const inference::ModelConfig& config)
+{
+  int nice = SCHEDULER_DEFAULT_NICE;
+  if (config.has_optimization()) {
+    switch (config.optimization().priority()) {
+      case inference::ModelOptimizationPolicy::PRIORITY_MAX:
+        nice = 0;
+        break;
+      case inference::ModelOptimizationPolicy::PRIORITY_MIN:
+        nice = 19;
+        break;
+      default:
+        nice = SCHEDULER_DEFAULT_NICE;
+        break;
+    }
+  }
+
+  return nice;
+}
+
+bool
+CompareDims(const DimsList& dims0, const DimsList& dims1)
+{
+  if (dims0.size() != dims1.size()) {
+    return false;
+  }
+
+  for (int i = 0; i < dims0.size(); ++i) {
+    if (dims0[i] != dims1[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
+CompareDims(
+    const std::vector<int64_t>& dims0, const std::vector<int64_t>& dims1)
+{
+  if (dims0.size() != dims1.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < dims0.size(); ++i) {
+    if (dims0[i] != dims1[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
+CompareDimsWithWildcard(const DimsList& dims0, const DimsList& dims1)
+{
+  if (dims0.size() != dims1.size()) {
+    return false;
+  }
+
+  for (int i = 0; i < dims0.size(); ++i) {
+    if ((dims0[i] != WILDCARD_DIM) && (dims1[i] != WILDCARD_DIM) &&
+        (dims0[i] != dims1[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
+CompareDimsWithWildcard(
+    const DimsList& dims0, const std::vector<int64_t>& dims1)
+{
+  if (dims0.size() != (int64_t)dims1.size()) {
+    return false;
+  }
+
+  for (int i = 0; i < dims0.size(); ++i) {
+    if ((dims0[i] != WILDCARD_DIM) && (dims1[i] != WILDCARD_DIM) &&
+        (dims0[i] != dims1[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::string
+DimsListToString(const DimsList& dims)
+{
+  bool first = true;
+
+  std::string str("[");
+  for (const auto& dim : dims) {
+    if (!first) {
+      str += ",";
+    }
+    str += std::to_string(dim);
+    first = false;
+  }
+
+  str += "]";
+  return str;
+}
+
+std::string
+DimsListToString(const std::vector<int64_t>& dims, const int start_idx)
+{
+  int idx = 0;
+
+  std::string str("[");
+  for (const auto& dim : dims) {
+    if (idx >= start_idx) {
+      if (idx > start_idx) {
+        str += ",";
+      }
+      str += std::to_string(dim);
+    }
+
+    idx++;
+  }
+
+  str += "]";
+  return str;
+}
+
+const char*
+DataTypeToProtocolString(const inference::DataType dtype)
+{
+  switch (dtype) {
+    case inference::DataType::TYPE_BOOL:
+      return "BOOL";
+    case inference::DataType::TYPE_UINT8:
+      return "UINT8";
+    case inference::DataType::TYPE_UINT16:
+      return "UINT16";
+    case inference::DataType::TYPE_UINT32:
+      return "UINT32";
+    case inference::DataType::TYPE_UINT64:
+      return "UINT64";
+    case inference::DataType::TYPE_INT8:
+      return "INT8";
+    case inference::DataType::TYPE_INT16:
+      return "INT16";
+    case inference::DataType::TYPE_INT32:
+      return "INT32";
+    case inference::DataType::TYPE_INT64:
+      return "INT64";
+    case inference::DataType::TYPE_FP16:
+      return "FP16";
+    case inference::DataType::TYPE_FP32:
+      return "FP32";
+    case inference::DataType::TYPE_FP64:
+      return "FP64";
+    case inference::DataType::TYPE_STRING:
+      return "BYTES";
+    default:
+      break;
+  }
+
+  return "<invalid>";
+}
+
+inference::DataType
+ProtocolStringToDataType(const std::string& dtype)
+{
+  return ProtocolStringToDataType(dtype.c_str(), dtype.size());
+}
+
+inference::DataType
+ProtocolStringToDataType(const char* dtype, size_t len)
+{
+  if (len < 4 || len > 6) {
+    return inference::DataType::TYPE_INVALID;
+  }
+
+  if ((*dtype == 'I') && (len != 6)) {
+    if ((dtype[1] == 'N') && (dtype[2] == 'T')) {
+      if ((dtype[3] == '8') && (len == 4)) {
+        return inference::DataType::TYPE_INT8;
+      } else if ((dtype[3] == '1') && (dtype[4] == '6')) {
+        return inference::DataType::TYPE_INT16;
+      } else if ((dtype[3] == '3') && (dtype[4] == '2')) {
+        return inference::DataType::TYPE_INT32;
+      } else if ((dtype[3] == '6') && (dtype[4] == '4')) {
+        return inference::DataType::TYPE_INT64;
+      }
+    }
+  } else if ((*dtype == 'U') && (len != 4)) {
+    if ((dtype[1] == 'I') && (dtype[2] == 'N') && (dtype[3] == 'T')) {
+      if ((dtype[4] == '8') && (len == 5)) {
+        return inference::DataType::TYPE_UINT8;
+      } else if ((dtype[4] == '1') && (dtype[5] == '6')) {
+        return inference::DataType::TYPE_UINT16;
+      } else if ((dtype[4] == '3') && (dtype[5] == '2')) {
+        return inference::DataType::TYPE_UINT32;
+      } else if ((dtype[4] == '6') && (dtype[5] == '4')) {
+        return inference::DataType::TYPE_UINT64;
+      }
+    }
+  } else if ((*dtype == 'F') && (dtype[1] == 'P') && (len == 4)) {
+    if ((dtype[2] == '1') && (dtype[3] == '6')) {
+      return inference::DataType::TYPE_FP16;
+    } else if ((dtype[2] == '3') && (dtype[3] == '2')) {
+      return inference::DataType::TYPE_FP32;
+    } else if ((dtype[2] == '6') && (dtype[3] == '4')) {
+      return inference::DataType::TYPE_FP64;
+    }
+  } else if (*dtype == 'B') {
+    if (dtype[1] == 'Y') {
+      if (!strcmp(dtype + 2, "TES")) {
+        return inference::DataType::TYPE_STRING;
+      }
+    } else if (!strcmp(dtype + 1, "OOL")) {
+      return inference::DataType::TYPE_BOOL;
+    }
+  }
+
+  return inference::DataType::TYPE_INVALID;
+}
+
+}}  // namespace triton::core


### PR DESCRIPTION
Addresses https://github.com/triton-inference-server/server/issues/2759: many of the functions in `model_config.h` are generically useful even on the client side and only depend on the generated protobuf headers. Therefore, it is useful to have them more broadly accessible via the common repo.

The header and cc files are copied here from the core repo (except for a few functions with non-trivial dependencies that stay in core), with the namespace changed to `triton::common`. A new library `triton-common-model-config` is built. Because many of the functions depend on the generated protobuf headers, this library is only built when the protobuf part of this repo is enabled.

This PR goes with https://github.com/triton-inference-server/core/pull/60.