### PR TITLE
Add ThreadPool to common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,34 @@ target_link_libraries(triton-common-async-work-queue
 )
 
 #
+# Thread Pool 
+#
+add_library(
+  triton-common-thread-pool
+  src/thread_pool.cc
+)
+
+add_library(
+  TritonCommon::triton-common-thread-pool ALIAS  triton-common-thread-pool
+)
+
+target_include_directories(
+  triton-common-thread-pool
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(triton-common-thread-pool
+  PUBLIC
+    Threads::Threads
+  PRIVATE
+    common-compile-settings
+)
+
+#
 # JSON utilities
 #
 if(TRITON_COMMON_ENABLE_JSON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ set_target_properties(
   triton-common-error
   triton-common-logging
   triton-common-table-printer
+  triton-common-thread-pool
   PROPERTIES
     WINDOWS_EXPORT_ALL_SYMBOLS TRUE
     POSITION_INDEPENDENT_CODE ON
@@ -335,11 +336,11 @@ set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/TritonCommon)
 install(
   TARGETS
     triton-common-async-work-queue
-    triton-common-thread-pool
     triton-common-error
     triton-common-logging
     triton-common-sync-queue
     triton-common-table-printer
+    triton-common-thread-pool
     common-compile-settings
   EXPORT
     triton-common-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/TritonCommon)
 install(
   TARGETS
     triton-common-async-work-queue
+    triton-common-thread-pool
     triton-common-error
     triton-common-logging
     triton-common-sync-queue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,12 @@ set_target_properties(
 )
 
 set_target_properties(
+  triton-common-thread-pool
+  PROPERTIES
+    OUTPUT_NAME tritonthreadpool
+)
+
+set_target_properties(
   triton-common-error
   PROPERTIES
     OUTPUT_NAME tritoncommonerror

--- a/cmake/TritonCommonConfig.cmake.in
+++ b/cmake/TritonCommonConfig.cmake.in
@@ -46,4 +46,5 @@ set(TRITONCOMMON_LIBRARIES
   TritonCommon::triton-common-json
   TritonCommon::triton-common-sync-queue
   TritonCommon::triton-common-async-work-queue
+  TritonCommon::triton-common-thread-pool
 )

--- a/cmake/TritonCommonConfig.cmake.in
+++ b/cmake/TritonCommonConfig.cmake.in
@@ -40,6 +40,7 @@ endif()
 check_required_components(triton-common-json
   triton-common-sync-queue
   triton-common-async-work-queue
+  triton-common-thread-pool
 )
 
 set(TRITONCOMMON_LIBRARIES 

--- a/include/triton/common/thread_pool.h
+++ b/include/triton/common/thread_pool.h
@@ -44,7 +44,7 @@ class ThreadPool {
   using Task = std::function<void(void)>;
   // Assigns "task" to the task queue for a worker thread to execute when
   // available. This will not track the return value of the task.
-  void enqueue(Task task);
+  void enqueue(Task&& task);
 
  private:
   std::queue<Task> task_queue_;

--- a/include/triton/common/thread_pool.h
+++ b/include/triton/common/thread_pool.h
@@ -28,6 +28,7 @@
 #include <condition_variable>
 #include <functional>
 #include <queue>
+#include <stdexcept>
 #include <thread>
 
 namespace triton { namespace common {

--- a/include/triton/common/thread_pool.h
+++ b/include/triton/common/thread_pool.h
@@ -28,7 +28,6 @@
 #include <condition_variable>
 #include <functional>
 #include <queue>
-#include <stdexcept>
 #include <thread>
 
 namespace triton { namespace common {

--- a/include/triton/common/thread_pool.h
+++ b/include/triton/common/thread_pool.h
@@ -1,0 +1,59 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <queue>
+#include <thread>
+
+namespace triton { namespace common {
+
+// Generic fixed-size Thread Pool to execute tasks asynchronously
+
+class ThreadPool {
+ public:
+  explicit ThreadPool(std::size_t thread_count);
+  ~ThreadPool();
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
+
+  using Task = std::function<void(void)>;
+  // Assigns "task" to the task queue for a worker thread to execute when
+  // available. This will not track the return value of the task.
+  void enqueue(Task task);
+
+ private:
+  std::queue<Task> task_queue_;
+  std::mutex queue_mtx_;
+  std::condition_variable cv_;
+  std::vector<std::thread> workers_;
+  // If true, tells pool to stop accepting work and tells awake worker threads
+  // to exit when no tasks are left on the queue.
+  bool stop_ = false;
+};
+
+}}  // namespace triton::common

--- a/src/thread_pool.cc
+++ b/src/thread_pool.cc
@@ -24,11 +24,11 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "../include/triton/common/thread_pool.h"
+#include "triton/common/thread_pool.h"
 
 namespace triton { namespace common {
 
-ThreadPool::ThreadPool(std::size_t thread_count)
+ThreadPool::ThreadPool(size_t thread_count)
 {
   if (!thread_count) {
     throw std::invalid_argument("Thread count must be greater than zero.");
@@ -58,7 +58,7 @@ ThreadPool::ThreadPool(std::size_t thread_count)
   };
 
   workers_.reserve(thread_count);
-  for (auto i = 0; i < thread_count; ++i) {
+  for (size_t i = 0; i < thread_count; ++i) {
     workers_.emplace_back(worker_loop);
   }
 }

--- a/src/thread_pool.cc
+++ b/src/thread_pool.cc
@@ -31,7 +31,8 @@ namespace triton { namespace common {
 ThreadPool::ThreadPool(size_t thread_count)
 {
   if (!thread_count) {
-    throw std::invalid_argument("Thread count must be greater than zero.");
+    // TODO
+    //throw std::invalid_argument("Thread count must be greater than zero.");
   }
 
   // Define infinite loop for each thread to wait for a task to complete

--- a/src/thread_pool.cc
+++ b/src/thread_pool.cc
@@ -79,7 +79,7 @@ ThreadPool::~ThreadPool()
 }
 
 void
-ThreadPool::enqueue(Task task)
+ThreadPool::enqueue(Task&& task)
 {
   {
     std::lock_guard<std::mutex> lk(queue_mtx_);

--- a/src/thread_pool.cc
+++ b/src/thread_pool.cc
@@ -25,14 +25,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "triton/common/thread_pool.h"
+#include <stdexcept>
 
 namespace triton { namespace common {
 
 ThreadPool::ThreadPool(size_t thread_count)
 {
   if (!thread_count) {
-    // TODO
-    //throw std::invalid_argument("Thread count must be greater than zero.");
+    throw std::invalid_argument("Thread count must be greater than zero.");
   }
 
   // Define infinite loop for each thread to wait for a task to complete

--- a/src/thread_pool.cc
+++ b/src/thread_pool.cc
@@ -1,0 +1,95 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "../include/triton/common/thread_pool.h"
+
+namespace triton { namespace common {
+
+ThreadPool::ThreadPool(std::size_t thread_count)
+{
+  if (!thread_count) {
+    throw std::invalid_argument("Thread count must be greater than zero.");
+  }
+
+  // Define infinite loop for each thread to wait for a task to complete
+  const auto worker_loop = [this]() {
+    while (true) {
+      Task task;
+      {
+        std::unique_lock<std::mutex> lk(queue_mtx_);
+        // Wake if there's a task to do, or the pool has been stopped.
+        cv_.wait(lk, [&]() { return !task_queue_.empty() || stop_; });
+        // Exit condition
+        if (stop_ && task_queue_.empty()) {
+          break;
+        }
+        task = std::move(task_queue_.front());
+        task_queue_.pop();
+      }
+
+      // Execute task - ensure function has a valid target
+      if (task) {
+        task();
+      }
+    }
+  };
+
+  workers_.reserve(thread_count);
+  for (auto i = 0; i < thread_count; ++i) {
+    workers_.emplace_back(worker_loop);
+  }
+}
+
+ThreadPool::~ThreadPool()
+{
+  {
+    std::lock_guard<std::mutex> lk(queue_mtx_);
+    // Signal to each worker that it should exit loop when tasks are finished
+    stop_ = true;
+  }
+  // Wake all threads to clean up
+  cv_.notify_all();
+  for (auto& t : workers_) {
+    t.join();
+  }
+}
+
+void
+ThreadPool::enqueue(Task task)
+{
+  {
+    std::lock_guard<std::mutex> lk(queue_mtx_);
+    // Don't accept more work if pool is shutting down
+    if (stop_) {
+      return;
+    }
+    task_queue_.push(std::move(task));
+  }
+  // Only wake one thread per task
+  cv_.notify_one();
+}
+
+}}  // namespace triton::common


### PR DESCRIPTION
Add simple ThreadPool implementation that doesn't rely on `boost::asio`

[common] Adds custom ThreadPool implementation in common: https://github.com/triton-inference-server/common/pull/60
[core] Use thread pool for loading models in model_repository_manager.cc: https://github.com/triton-inference-server/core/pull/86
[server] Expose num threads to server CLI: https://github.com/triton-inference-server/server/pull/4500

> NOTE: Will update `AsyncWorkQueue` to use `ThreadPool` internally in a follow-up ticket (DLIS-3860) to only maintain one implementation, and not have `ThreadPool` be restricted to only being a singleton like AsyncWorkQueue currently is. 