### PR TITLE
Remove Name Collision (GetObject)

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -638,7 +638,7 @@ class TritonJson {
         TRITONJSON_STATUSRETURN(
             std::string("attempt to get members for non-object"));
       }
-      for (const auto& m : object.GetObject()) {
+      for (const auto& m : object.GetObj()) {
         names->push_back(m.name.GetString());
       }
       return TRITONJSON_STATUSSUCCESS;

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -26,6 +26,10 @@
 #pragma once
 
 #ifdef _WIN32
+// Remove GetObject definition from windows.h, which prevents calls to
+// RapidJSON's GetObject.
+// https://github.com/Tencent/rapidjson/issues/1448
+#undef GetObject
 #include <rapidjson/document.h>
 #else
 // Disable class-memaccess warning to facilitate compilation with gcc>7
@@ -638,7 +642,7 @@ class TritonJson {
         TRITONJSON_STATUSRETURN(
             std::string("attempt to get members for non-object"));
       }
-      for (const auto& m : object.GetObj()) {
+      for (const auto& m : object.GetObject()) {
         names->push_back(m.name.GetString());
       }
       return TRITONJSON_STATUSSUCCESS;


### PR DESCRIPTION
Non-Docker Windows compilation fails on some machines due to a preprocessor macro for GetObject redefining GetObject to GetObjectA/GetObjectW in `windows.h`. The fix was imported to the main branch of RapidJSON last year (using GetObj as an alias for GetObject). However, there has not been a release of RapidJSON since 2016 and there is not one planned yet.

Undefining the preprocessor macro resolves this compilation failure for Windows machines.

See RapidJSON issue thread here: https://github.com/Tencent/rapidjson/issues/1448