### PR TITLE
Add protobuf for GRPC health check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ endif()
 if(${TRITON_COMMON_ENABLE_GRPC})
   install(
     TARGETS
-      health-library
+      grpc-health-library
       grpc-service-library
 #      grpc-service-py-library
     EXPORT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ if(${TRITON_COMMON_ENABLE_GRPC})
   install(
     TARGETS
       grpc-service-library
+      health-library
 #      grpc-service-py-library
     EXPORT
       triton-common-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,8 +376,8 @@ endif()
 if(${TRITON_COMMON_ENABLE_GRPC})
   install(
     TARGETS
-      grpc-service-library
       health-library
+      grpc-service-library
 #      grpc-service-py-library
     EXPORT
       triton-common-targets

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -183,25 +183,25 @@ if(${TRITON_COMMON_ENABLE_GRPC})
   )
 
   add_library(
-    health-library EXCLUDE_FROM_ALL OBJECT
+    grpc-health-library EXCLUDE_FROM_ALL OBJECT
     ${HEALTH_SRCS} ${HEALTH_HDRS}
   )
 
   target_include_directories(
-    health-library
+    grpc-health-library
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   )
 
   target_compile_options(
-    health-library PRIVATE
+    grpc-health-library PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
       -Wall -Wextra -Wno-unused-parameter -Werror>
     $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
   )
 
   set_target_properties(
-    health-library
+    grpc-health-library
     PROPERTIES
       POSITION_INDEPENDENT_CODE ON
   )

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -88,80 +88,6 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF})
 endif()
 
 #
-# GRPC
-#
-if(${TRITON_COMMON_ENABLE_GRPC})
-  get_filename_component(grpc_service_proto_abspath "grpc_service.proto" ABSOLUTE)
-  get_filename_component(grpc_service_proto_dir "${grpc_service_proto_abspath}" PATH)
-  set(GRPC_SRCS "grpc_service.grpc.pb.cc")
-  set(GRPC_HDRS "grpc_service.grpc.pb.h")
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    set(GRPC_PY "grpc_service.grpc.py")
-  endif()
-
-  add_custom_command(
-    OUTPUT "${GRPC_SRCS}" "${GRPC_HDRS}"
-    COMMAND ${_PROTOBUF_PROTOC}
-    ARGS
-      --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
-      --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
-      -I "${grpc_service_proto_dir}"
-      --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
-      "grpc_service.proto"
-    DEPENDS "grpc_service.proto" proto-library
-  )
-
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    find_package(Python REQUIRED COMPONENTS Interpreter)
-    add_custom_command(
-      OUTPUT "${GRPC_PY}"
-      COMMAND ${Python_EXECUTABLE}
-      ARGS
-        -m grpc_tools.protoc
-        -I "${grpc_service_proto_dir}"
-        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
-        "grpc_service.proto"
-      DEPENDS "grpc_service.proto" proto-library
-    )
-  endif()
-
-  add_library(
-    grpc-service-library EXCLUDE_FROM_ALL OBJECT
-    ${GRPC_SRCS} ${GRPC_HDRS}
-  )
-
-  target_include_directories(
-    grpc-service-library
-    PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-  )
-
-  target_compile_options(
-    grpc-service-library PRIVATE
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-      -Wall -Wextra -Wno-unused-parameter -Werror>
-    $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
-  )
-
-  set_target_properties(
-    grpc-service-library
-    PROPERTIES
-      POSITION_INDEPENDENT_CODE ON
-  )
-
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    add_custom_target(grpc-service-py-library DEPENDS ${GRPC_PY})
-  endif()
-
-  install(
-    FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/grpc_service.grpc.pb.h
-    DESTINATION include
-    OPTIONAL
-  )
-endif()
-
-#
 # GRPC Health Service
 #
 if(${TRITON_COMMON_ENABLE_GRPC})
@@ -230,6 +156,80 @@ if(${TRITON_COMMON_ENABLE_GRPC})
   install(
     FILES
       ${CMAKE_CURRENT_BINARY_DIR}/health.grpc.pb.h
+    DESTINATION include
+    OPTIONAL
+  )
+endif()
+
+#
+# GRPC
+#
+if(${TRITON_COMMON_ENABLE_GRPC})
+  get_filename_component(grpc_service_proto_abspath "grpc_service.proto" ABSOLUTE)
+  get_filename_component(grpc_service_proto_dir "${grpc_service_proto_abspath}" PATH)
+  set(GRPC_SRCS "grpc_service.grpc.pb.cc")
+  set(GRPC_HDRS "grpc_service.grpc.pb.h")
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    set(GRPC_PY "grpc_service.grpc.py")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${GRPC_SRCS}" "${GRPC_HDRS}"
+    COMMAND ${_PROTOBUF_PROTOC}
+    ARGS
+      --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+      --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+      -I "${grpc_service_proto_dir}"
+      --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+      "grpc_service.proto"
+    DEPENDS "grpc_service.proto" proto-library
+  )
+
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    add_custom_command(
+      OUTPUT "${GRPC_PY}"
+      COMMAND ${Python_EXECUTABLE}
+      ARGS
+        -m grpc_tools.protoc
+        -I "${grpc_service_proto_dir}"
+        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
+        "grpc_service.proto"
+      DEPENDS "grpc_service.proto" proto-library
+    )
+  endif()
+
+  add_library(
+    grpc-service-library EXCLUDE_FROM_ALL OBJECT
+    ${GRPC_SRCS} ${GRPC_HDRS}
+  )
+
+  target_include_directories(
+    grpc-service-library
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  )
+
+  target_compile_options(
+    grpc-service-library PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+      -Wall -Wextra -Wno-unused-parameter -Werror>
+    $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
+  )
+
+  set_target_properties(
+    grpc-service-library
+    PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+  )
+
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    add_custom_target(grpc-service-py-library DEPENDS ${GRPC_PY})
+  endif()
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/grpc_service.grpc.pb.h
     DESTINATION include
     OPTIONAL
   )

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -160,3 +160,77 @@ if(${TRITON_COMMON_ENABLE_GRPC})
     OPTIONAL
   )
 endif()
+
+#
+# GRPC Health Service
+#
+if(${TRITON_COMMON_ENABLE_GRPC})
+  get_filename_component(health_proto_abspath "health.proto" ABSOLUTE)
+  get_filename_component(health_proto_dir "${health_proto_abspath}" PATH)
+  set(HEALTH_SRCS "health.grpc.pb.cc")
+  set(HEALTH_HDRS "health.grpc.pb.h")
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    set(HEALTH_PY "health.grpc.py")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${HEALTH_SRCS}" "${HEALTH_HDRS}"
+    COMMAND ${_PROTOBUF_PROTOC}
+    ARGS
+      --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+      --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+      -I "${health_proto_dir}"
+      --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+      "health.proto"
+    DEPENDS "health.proto" proto-library
+  )
+
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    add_custom_command(
+      OUTPUT "${HEALTH_PY}"
+      COMMAND ${Python_EXECUTABLE}
+      ARGS
+        -m grpc_tools.protoc
+        -I "${health_proto_dir}"
+        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
+        "health.proto"
+      DEPENDS "health.proto" proto-library
+    )
+  endif()
+
+  add_library(
+    health-library EXCLUDE_FROM_ALL OBJECT
+    ${HEALTH_SRCS} ${HEALTH_HDRS}
+  )
+
+  target_include_directories(
+    health-library
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  )
+
+  target_compile_options(
+    health-library PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+      -Wall -Wextra -Wno-unused-parameter -Werror>
+    $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
+  )
+
+  set_target_properties(
+    health-library
+    PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+  )
+
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    add_custom_target(health-py-library DEPENDS ${HEALTH_PY})
+  endif()
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/health.grpc.pb.h
+    DESTINATION include
+    OPTIONAL
+  )
+endif()

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -88,80 +88,6 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF})
 endif()
 
 #
-# GRPC Health Service
-#
-if(${TRITON_COMMON_ENABLE_GRPC})
-  get_filename_component(health_proto_abspath "health.proto" ABSOLUTE)
-  get_filename_component(health_proto_dir "${health_proto_abspath}" PATH)
-  set(HEALTH_SRCS "health.grpc.pb.cc")
-  set(HEALTH_HDRS "health.grpc.pb.h")
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    set(HEALTH_PY "health.grpc.py")
-  endif()
-
-  add_custom_command(
-    OUTPUT "${HEALTH_SRCS}" "${HEALTH_HDRS}"
-    COMMAND ${_PROTOBUF_PROTOC}
-    ARGS
-      --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
-      --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
-      -I "${health_proto_dir}"
-      --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
-      "health.proto"
-    DEPENDS "health.proto" proto-library
-  )
-
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    find_package(Python REQUIRED COMPONENTS Interpreter)
-    add_custom_command(
-      OUTPUT "${HEALTH_PY}"
-      COMMAND ${Python_EXECUTABLE}
-      ARGS
-        -m grpc_tools.protoc
-        -I "${health_proto_dir}"
-        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
-        "health.proto"
-      DEPENDS "health.proto" proto-library
-    )
-  endif()
-
-  add_library(
-    health-library EXCLUDE_FROM_ALL OBJECT
-    ${HEALTH_SRCS} ${HEALTH_HDRS}
-  )
-
-  target_include_directories(
-    health-library
-    PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-  )
-
-  target_compile_options(
-    health-library PRIVATE
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-      -Wall -Wextra -Wno-unused-parameter -Werror>
-    $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
-  )
-
-  set_target_properties(
-    health-library
-    PROPERTIES
-      POSITION_INDEPENDENT_CODE ON
-  )
-
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    add_custom_target(health-py-library DEPENDS ${HEALTH_PY})
-  endif()
-
-  install(
-    FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/health.grpc.pb.h
-    DESTINATION include
-    OPTIONAL
-  )
-endif()
-
-#
 # GRPC
 #
 if(${TRITON_COMMON_ENABLE_GRPC})
@@ -230,6 +156,80 @@ if(${TRITON_COMMON_ENABLE_GRPC})
   install(
     FILES
       ${CMAKE_CURRENT_BINARY_DIR}/grpc_service.grpc.pb.h
+    DESTINATION include
+    OPTIONAL
+  )
+endif()
+
+#
+# GRPC Health Service
+#
+if(${TRITON_COMMON_ENABLE_GRPC})
+  get_filename_component(health_proto_abspath "health.proto" ABSOLUTE)
+  get_filename_component(health_proto_dir "${health_proto_abspath}" PATH)
+  set(HEALTH_SRCS "health.grpc.pb.cc")
+  set(HEALTH_HDRS "health.grpc.pb.h")
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    set(HEALTH_PY "health.grpc.py")
+  endif()
+
+  add_custom_command(
+    OUTPUT "${HEALTH_SRCS}" "${HEALTH_HDRS}"
+    COMMAND ${_PROTOBUF_PROTOC}
+    ARGS
+      --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+      --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+      -I "${health_proto_dir}"
+      --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+      "health.proto"
+    DEPENDS "health.proto" proto-library
+  )
+
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    add_custom_command(
+      OUTPUT "${HEALTH_PY}"
+      COMMAND ${Python_EXECUTABLE}
+      ARGS
+        -m grpc_tools.protoc
+        -I "${health_proto_dir}"
+        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
+        "health.proto"
+      DEPENDS "health.proto" proto-library
+    )
+  endif()
+
+  add_library(
+    health-library EXCLUDE_FROM_ALL OBJECT
+    ${HEALTH_SRCS} ${HEALTH_HDRS}
+  )
+
+  target_include_directories(
+    health-library
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  )
+
+  target_compile_options(
+    health-library PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+      -Wall -Wextra -Wno-unused-parameter -Werror>
+    $<$<CXX_COMPILER_ID:MSVC>:/W0 /D_WIN32_WINNT=0x0A00 /EHsc>
+  )
+
+  set_target_properties(
+    health-library
+    PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+  )
+
+  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
+    add_custom_target(health-py-library DEPENDS ${HEALTH_PY})
+  endif()
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/health.grpc.pb.h
     DESTINATION include
     OPTIONAL
   )

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -169,9 +169,6 @@ if(${TRITON_COMMON_ENABLE_GRPC})
   get_filename_component(health_proto_dir "${health_proto_abspath}" PATH)
   set(HEALTH_SRCS "health.grpc.pb.cc")
   set(HEALTH_HDRS "health.grpc.pb.h")
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    set(HEALTH_PY "health.grpc.py")
-  endif()
 
   add_custom_command(
     OUTPUT "${HEALTH_SRCS}" "${HEALTH_HDRS}"
@@ -184,20 +181,6 @@ if(${TRITON_COMMON_ENABLE_GRPC})
       "health.proto"
     DEPENDS "health.proto" proto-library
   )
-
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    find_package(Python REQUIRED COMPONENTS Interpreter)
-    add_custom_command(
-      OUTPUT "${HEALTH_PY}"
-      COMMAND ${Python_EXECUTABLE}
-      ARGS
-        -m grpc_tools.protoc
-        -I "${health_proto_dir}"
-        --grpc_python_out "${CMAKE_CURRENT_BINARY_DIR}"
-        "health.proto"
-      DEPENDS "health.proto" proto-library
-    )
-  endif()
 
   add_library(
     health-library EXCLUDE_FROM_ALL OBJECT
@@ -222,10 +205,6 @@ if(${TRITON_COMMON_ENABLE_GRPC})
     PROPERTIES
       POSITION_INDEPENDENT_CODE ON
   )
-
-  if(TRITON_COMMON_ENABLE_PROTOBUF_PYTHON)
-    add_custom_target(health-py-library DEPENDS ${HEALTH_PY})
-  endif()
 
   install(
     FILES

--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -1697,3 +1697,32 @@ message LogSettingsResponse
   map<string, SettingValue> settings = 1;
 }
 
+//@@
+//@@.. cpp:var:: message HealthCheckRequest
+//@@
+//@@   Request message for HealthCheck
+//@@
+message HealthCheckRequest {
+  string service = 1;
+}
+
+//@@
+//@@.. cpp:var:: message HealthCheckResponse
+//@@
+//@@   Response message for HealthCheck
+//@@
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -208,18 +208,14 @@ service GRPCInferenceService
   //@@
   //@@     Update and get the trace setting of the Triton server.
   //@@
-  rpc TraceSetting(TraceSettingRequest) returns (TraceSettingResponse)
-  {
-  }
+  rpc TraceSetting(TraceSettingRequest) returns (TraceSettingResponse) {}
 
   //@@  .. cpp:var:: rpc LogSettings(LogSettingsRequest)
   //@@                   returns (LogSettingsResponse)
   //@@
   //@@     Update and get the log settings of the Triton server.
   //@@
-  rpc LogSettings(LogSettingsRequest) returns (LogSettingsResponse)
-  {
-  }
+  rpc LogSettings(LogSettingsRequest) returns (LogSettingsResponse) {}
 }
 
 //@@
@@ -927,7 +923,7 @@ message InferStatistics
   //@@  .. cpp:var:: StatisticDuration queue
   //@@
   //@@     The count and cumulative duration that inference requests wait in
-  //@@     scheduling or other queues. The "queue" count and cumulative 
+  //@@     scheduling or other queues. The "queue" count and cumulative
   //@@     duration includes cache hits.
   //@@
   StatisticDuration queue = 3;
@@ -969,7 +965,7 @@ message InferStatistics
   //@@     and extract output tensor data from the Response Cache on a cache
   //@@     hit. For example, this duration should include the time to copy
   //@@     output tensor data from the Response Cache to the response object.
-  //@@     On cache hits, triton does not need to go to the model/backend 
+  //@@     On cache hits, triton does not need to go to the model/backend
   //@@     for the output tensor data, so the "compute_input", "compute_infer",
   //@@     and "compute_output" fields are not updated. Assuming the response
   //@@     cache is enabled for a given model, a cache hit occurs for a
@@ -977,21 +973,24 @@ message InferStatistics
   //@@     model version, model inputs) hashes to an existing entry in the
   //@@     cache. On a cache miss, the request hash and response output tensor
   //@@     data is added to the cache. See response cache docs for more info:
-  //@@     https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
+  //@@
+  //https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
   //@@
   StatisticDuration cache_hit = 7;
 
   //@@  .. cpp:var:: StatisticDuration cache_miss
   //@@
   //@@     The count of response cache misses and cumulative duration to lookup
-  //@@     and insert output tensor data from the computed response to the cache.
+  //@@     and insert output tensor data from the computed response to the
+  //cache.
   //@@     For example, this duration should include the time to copy
   //@@     output tensor data from the response object to the Response Cache.
   //@@     Assuming the response cache is enabled for a given model, a cache
   //@@     miss occurs for a request to that model when the request metadata
   //@@     does NOT hash to an existing entry in the cache. See the response
   //@@     cache docs for more info:
-  //@@     https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
+  //@@
+  //https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
   //@@
   StatisticDuration cache_miss = 8;
 }
@@ -1702,7 +1701,8 @@ message LogSettingsResponse
 //@@
 //@@   Request message for HealthCheck
 //@@
-message HealthCheckRequest {
+message HealthCheckRequest
+{
   string service = 1;
 }
 
@@ -1711,7 +1711,8 @@ message HealthCheckRequest {
 //@@
 //@@   Response message for HealthCheck
 //@@
-message HealthCheckResponse {
+message HealthCheckResponse
+{
   enum ServingStatus {
     UNKNOWN = 0;
     SERVING = 1;
@@ -1721,7 +1722,8 @@ message HealthCheckResponse {
   ServingStatus status = 1;
 }
 
-service Health {
+service Health
+{
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 
   rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);

--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -923,7 +923,7 @@ message InferStatistics
   //@@  .. cpp:var:: StatisticDuration queue
   //@@
   //@@     The count and cumulative duration that inference requests wait in
-  //@@     scheduling or other queues. The "queue" count and cumulative
+  //@@     scheduling or other queues. The "queue" count and cumulative 
   //@@     duration includes cache hits.
   //@@
   StatisticDuration queue = 3;
@@ -965,7 +965,7 @@ message InferStatistics
   //@@     and extract output tensor data from the Response Cache on a cache
   //@@     hit. For example, this duration should include the time to copy
   //@@     output tensor data from the Response Cache to the response object.
-  //@@     On cache hits, triton does not need to go to the model/backend
+  //@@     On cache hits, triton does not need to go to the model/backend 
   //@@     for the output tensor data, so the "compute_input", "compute_infer",
   //@@     and "compute_output" fields are not updated. Assuming the response
   //@@     cache is enabled for a given model, a cache hit occurs for a
@@ -973,24 +973,21 @@ message InferStatistics
   //@@     model version, model inputs) hashes to an existing entry in the
   //@@     cache. On a cache miss, the request hash and response output tensor
   //@@     data is added to the cache. See response cache docs for more info:
-  //@@
-  //https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
+  //@@     https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
   //@@
   StatisticDuration cache_hit = 7;
 
   //@@  .. cpp:var:: StatisticDuration cache_miss
   //@@
   //@@     The count of response cache misses and cumulative duration to lookup
-  //@@     and insert output tensor data from the computed response to the
-  //cache.
+  //@@     and insert output tensor data from the computed response to the cache.
   //@@     For example, this duration should include the time to copy
   //@@     output tensor data from the response object to the Response Cache.
   //@@     Assuming the response cache is enabled for a given model, a cache
   //@@     miss occurs for a request to that model when the request metadata
   //@@     does NOT hash to an existing entry in the cache. See the response
   //@@     cache docs for more info:
-  //@@
-  //https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
+  //@@     https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md
   //@@
   StatisticDuration cache_miss = 8;
 }
@@ -1694,37 +1691,4 @@ message LogSettingsResponse
   //@@     The current log settings.
   //@@
   map<string, SettingValue> settings = 1;
-}
-
-//@@
-//@@.. cpp:var:: message HealthCheckRequest
-//@@
-//@@   Request message for HealthCheck
-//@@
-message HealthCheckRequest
-{
-  string service = 1;
-}
-
-//@@
-//@@.. cpp:var:: message HealthCheckResponse
-//@@
-//@@   Response message for HealthCheck
-//@@
-message HealthCheckResponse
-{
-  enum ServingStatus {
-    UNKNOWN = 0;
-    SERVING = 1;
-    NOT_SERVING = 2;
-    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
-  }
-  ServingStatus status = 1;
-}
-
-service Health
-{
-  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
-
-  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
 }

--- a/protobuf/health.proto
+++ b/protobuf/health.proto
@@ -1,0 +1,61 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+//@@.. cpp:namespace:: grpc.health.v1
+
+//@@
+//@@.. cpp:var:: message HealthCheckRequest
+//@@
+//@@   Request message for HealthCheck
+//@@
+message HealthCheckRequest {
+  string service = 1;
+}
+
+//@@
+//@@.. cpp:var:: message HealthCheckResponse
+//@@
+//@@   Response message for HealthCheck
+//@@
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/protobuf/health.proto
+++ b/protobuf/health.proto
@@ -47,6 +47,11 @@ message HealthCheckRequest
 //@@
 message HealthCheckResponse
 {
+  //@@
+  //@@.. cpp:enum:: ServingStatus
+  //@@
+  //@@   Statuses supported by GRPC's health check.
+  //@@
   enum ServingStatus {
     UNKNOWN = 0;
     SERVING = 1;
@@ -56,9 +61,25 @@ message HealthCheckResponse
   ServingStatus status = 1;
 }
 
+//@@
+//@@.. cpp:var:: service Health
+//@@
+//@@   Health service for GRPC endpoints.
+//@@
 service Health
 {
+  //@@  .. cpp:var:: rpc Check(HealthCheckRequest) returns
+  //@@       (HealthCheckResponse)
+  //@@
+  //@@     Get serving status of the inference server.
+  //@@
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 
+  //@@  .. cpp:var:: rpc Watch(HealthCheckRequest) returns
+  //@@       (stream HealthCheckResponse)
+  //@@
+  //@@     Get current serving status of the inference server and
+  //@@     future status changes. This is not implemented.
+  //@@
   rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
 }

--- a/protobuf/health.proto
+++ b/protobuf/health.proto
@@ -56,7 +56,7 @@ message HealthCheckResponse
     UNKNOWN = 0;
     SERVING = 1;
     NOT_SERVING = 2;
-    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+    SERVICE_UNKNOWN = 3;
   }
   ServingStatus status = 1;
 }
@@ -74,12 +74,4 @@ service Health
   //@@     Get serving status of the inference server.
   //@@
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
-
-  //@@  .. cpp:var:: rpc Watch(HealthCheckRequest) returns
-  //@@       (stream HealthCheckResponse)
-  //@@
-  //@@     Get current serving status of the inference server and
-  //@@     future status changes. This is not implemented.
-  //@@
-  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
 }

--- a/protobuf/health.proto
+++ b/protobuf/health.proto
@@ -35,7 +35,8 @@ package grpc.health.v1;
 //@@
 //@@   Request message for HealthCheck
 //@@
-message HealthCheckRequest {
+message HealthCheckRequest
+{
   string service = 1;
 }
 
@@ -44,7 +45,8 @@ message HealthCheckRequest {
 //@@
 //@@   Response message for HealthCheck
 //@@
-message HealthCheckResponse {
+message HealthCheckResponse
+{
   enum ServingStatus {
     UNKNOWN = 0;
     SERVING = 1;
@@ -54,7 +56,8 @@ message HealthCheckResponse {
   ServingStatus status = 1;
 }
 
-service Health {
+service Health
+{
   rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
 
   rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1311,7 +1311,8 @@ message ModelSequenceBatching
 
     //@@      .. cpp:var:: int64 dims (repeated)
     //@@
-    //@@         The shape of the state tensor, not including the batch dimension.
+    //@@         The shape of the state tensor, not including the batch
+    //dimension.
     //@@
     repeated int64 dims = 2;
 
@@ -1640,7 +1641,7 @@ message ModelWarmup
       //@@       row-major order. The file must be provided in a sub-directory
       //@@       'warmup' under the model directory. The file contents should be
       //@@       in binary format. For TYPE_STRING data-type, an element is
-      //@@       represented by a 4-byte unsigned integer giving the length 
+      //@@       represented by a 4-byte unsigned integer giving the length
       //@@       followed by the actual bytes.
       //@@
       string input_data_file = 5;

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -1312,7 +1312,7 @@ message ModelSequenceBatching
     //@@      .. cpp:var:: int64 dims (repeated)
     //@@
     //@@         The shape of the state tensor, not including the batch
-    //dimension.
+    //@@         dimension.
     //@@
     repeated int64 dims = 2;
 


### PR DESCRIPTION
Add GRPC's standard health check protocol. This can be used with tools like grpc-health-probe and Kubernetes liveness probes (as of [Kubernetes 1.24](https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/)).

Related server PR (implementation, tests): https://github.com/triton-inference-server/server/pull/5267