### PR TITLE
Fix rapidjson build in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ endif()
 
 add_library(common-compile-settings INTERFACE)
 
+target_compile_definitions(common-compile-settings INTERFACE NOMINMAX)
+
 target_compile_features(common-compile-settings INTERFACE cxx_std_11)
 
 target_compile_options(common-compile-settings INTERFACE

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -30,6 +30,8 @@
 // RapidJSON's GetObject.
 // https://github.com/Tencent/rapidjson/issues/1448
 #undef GetObject
+// Define NOMINMAX to build successfully with std::min/max
+#define NOMINMAX
 #include <rapidjson/document.h>
 #else
 // Disable class-memaccess warning to facilitate compilation with gcc>7

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -30,8 +30,6 @@
 // RapidJSON's GetObject.
 // https://github.com/Tencent/rapidjson/issues/1448
 #undef GetObject
-// Define NOMINMAX to build successfully with std::min/max
-#define NOMINMAX
 #include <rapidjson/document.h>
 #else
 // Disable class-memaccess warning to facilitate compilation with gcc>7


### PR DESCRIPTION
re2/stringpiece.h uses std::min/max which seems to be breaking rapidjson build on windows.

https://github.com/google/re2/blob/2022-06-01/re2/stringpiece.h#L141
