### PR TITLE
Updating Service and Model Config Protobuf for uint64 Request Priority

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -239,6 +239,15 @@ class TritonJson {
       return TRITONJSON_STATUSSUCCESS;
     }
 
+    // Set/overwrite an unsigned integer in a value. This changes the
+    // type of the value to unsigned int.
+    TRITONJSON_STATUSTYPE SetUInt(const uint64_t value)
+    {
+      rapidjson::Value& v = AsMutableValue();
+      v.SetUint64(value);
+      return TRITONJSON_STATUSSUCCESS;
+    }
+
     // Set/overwrite a string in a value. This changes the
     // type of the value to string
     TRITONJSON_STATUSTYPE SetString(const std::string& value)

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -228,8 +228,6 @@ class TritonJson {
       return TRITONJSON_STATUSSUCCESS;
     }
 
-    // FIXME Should have Set* for all types.
-
     // Set/overwrite a signed integer in a value. This changes the
     // type of the value to signed int.
     TRITONJSON_STATUSTYPE SetInt(const int64_t value)
@@ -248,6 +246,15 @@ class TritonJson {
       return TRITONJSON_STATUSSUCCESS;
     }
 
+    // Set/overwrite a double in a value. This changes the
+    // type of the value to double.
+    TRITONJSON_STATUSTYPE SetDouble(const double value)
+    {
+      rapidjson::Value& v = AsMutableValue();
+      v.SetDouble(value);
+      return TRITONJSON_STATUSSUCCESS;
+    }
+    
     // Set/overwrite a string in a value. This changes the
     // type of the value to string
     TRITONJSON_STATUSTYPE SetString(const std::string& value)

--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -440,8 +440,12 @@ message InferParameter
 {
   //@@  .. cpp:var:: oneof parameter_choice
   //@@
-  //@@     The parameter value can be a string, an int64 or
-  //@@     a boolean
+  //@@     The parameter value can be a string, an int64,
+  //@@     an uint64, a double, or a boolean
+  //@@
+  //@@     Note: double and uint64 are currently
+  //@@           placeholders for future use and
+  //@@           are not supported for custom parameters
   //@@
   oneof parameter_choice
   {
@@ -467,11 +471,15 @@ message InferParameter
     //@@
     //@@       A double parameter value.
     //@@
+    //@@       Not supported for custom parameters
+    //@@
     double double_param = 4;
 
     //@@    .. cpp:var:: uint64 uint64_param
     //@@
     //@@       A uint64 parameter value.
+    //@@
+    //@@       Not supported for custom parameters
     //@@
     uint64 uint64_param = 5;
   }

--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -462,6 +462,18 @@ message InferParameter
     //@@       A string parameter value.
     //@@
     string string_param = 3;
+
+    //@@    .. cpp:var:: double double_param
+    //@@
+    //@@       A double parameter value.
+    //@@
+    double double_param = 4;
+
+    //@@    .. cpp:var:: uint64 uint64_param
+    //@@
+    //@@       A uint64 parameter value.
+    //@@
+    uint64 uint64_param = 5;
   }
 }
 

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1134,7 +1134,7 @@ message ModelDynamicBatching
   //@@
   bool preserve_ordering = 3;
 
-  //@@  .. cpp:var:: uint32 priority_levels
+  //@@  .. cpp:var:: uint64 priority_levels
   //@@
   //@@     The number of priority levels to be enabled for the model,
   //@@     the priority level starts from 1 and 1 is the highest priority.
@@ -1143,14 +1143,14 @@ message ModelDynamicBatching
   //@@     priority 3, etc. Requests with the same priority level will be
   //@@     handled in the order that they are received.
   //@@
-  uint32 priority_levels = 4;
+  uint64 priority_levels = 4;
 
-  //@@  .. cpp:var:: uint32 default_priority_level
+  //@@  .. cpp:var:: uint64 default_priority_level
   //@@
   //@@     The priority level used for requests that don't specify their
   //@@     priority. The value must be in the range [ 1, 'priority_levels' ].
   //@@
-  uint32 default_priority_level = 5;
+  uint64 default_priority_level = 5;
 
   //@@  .. cpp:var:: ModelQueuePolicy default_queue_policy
   //@@
@@ -1161,13 +1161,13 @@ message ModelDynamicBatching
   //@@
   ModelQueuePolicy default_queue_policy = 6;
 
-  //@@  .. cpp:var:: map<uint32, ModelQueuePolicy> priority_queue_policy
+  //@@  .. cpp:var:: map<uint64, ModelQueuePolicy> priority_queue_policy
   //@@
   //@@     Specify the queue policy for the priority level. The default queue
   //@@     policy will be used if a priority level doesn't specify a queue
   //@@     policy.
   //@@
-  map<uint32, ModelQueuePolicy> priority_queue_policy = 7;
+  map<uint64, ModelQueuePolicy> priority_queue_policy = 7;
 }
 
 //@@


### PR DESCRIPTION
Updating priority levels within model config proto to support uint64 (allows for utilizing timestamps as priority).
See discussion here https://github.com/triton-inference-server/common/pull/82#issuecomment-1547650136.

In addition update the InferParameter choices to include double and uint64.

Double is to keep consistent with other inference servers - in anticipation of KServe protobuf's changes.