### PR TITLE
Update clang format version

### DIFF
--- a/tools/format.py
+++ b/tools/format.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ def visit(path):
                                          style_config='google')
         return True
     else:
-        args = ['clang-format-6.0', '--style=file', '-i']
+        args = ['clang-format-15', '--style=file', '-i']
         if FLAGS.verbose:
             args.append('-verbose')
         args.append(path)


### PR DESCRIPTION
The build container is now built on Ubuntu 22.04, which has clang-format-11 through clang-format-15. As a result, I'd like to update the clang format version so that we can continue to use it in the build container.

This is tested locally. When run on already-formatted files, it formats minimally. It does look like 15 has a few changes from clang-format-6.0 but the format generally makes sense.