### PR TITLE
Add mutex to logger to avoid race condition

### DIFF
--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -128,7 +128,6 @@ class Logger {
   // Get the mutex.
   std::mutex& GetMutex() { return mutex_; }
 
-
  private:
   std::vector<bool> enables_;
   uint32_t vlevel_;

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -126,10 +126,7 @@ class Logger {
   void Flush();
 
   // Get the mutex.
-  std::mutex& GetMutex()
-    {
-        return mutex_;
-    }
+  std::mutex& GetMutex() { return mutex_; }
 
 
  private:

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -125,6 +125,13 @@ class Logger {
   // Flush the log.
   void Flush();
 
+  // Get the mutex.
+  std::mutex& GetMutex()
+    {
+        return mutex_;
+    }
+
+
  private:
   std::vector<bool> enables_;
   uint32_t vlevel_;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -84,26 +84,32 @@ LogMessage::LogMessage(const char* file, int line, uint32_t level)
 #ifdef _WIN32
       SYSTEMTIME system_time;
       GetSystemTime(&system_time);
-      stream_ << level_name_[std::min(level, (uint32_t)Level::kINFO)]
-              << std::setfill('0') << std::setw(2) << system_time.wMonth
-              << std::setw(2) << system_time.wDay << ' ' << std::setw(2)
-              << system_time.wHour << ':' << std::setw(2) << system_time.wMinute
-              << ':' << std::setw(2) << system_time.wSecond << '.'
-              << std::setw(6) << system_time.wMilliseconds * 1000 << ' '
-              << static_cast<uint32_t>(GetCurrentProcessId()) << ' ' << path
-              << ':' << line << "] ";
+      {
+        std::lock_guard<std::mutex> lk(gLogger_.GetMutex());
+        stream_ << level_name_[std::min(level, (uint32_t)Level::kINFO)]
+                << std::setfill('0') << std::setw(2) << system_time.wMonth
+                << std::setw(2) << system_time.wDay << ' ' << std::setw(2)
+                << system_time.wHour << ':' << std::setw(2) << system_time.wMinute
+                << ':' << std::setw(2) << system_time.wSecond << '.'
+                << std::setw(6) << system_time.wMilliseconds * 1000 << ' '
+                << static_cast<uint32_t>(GetCurrentProcessId()) << ' ' << path
+                << ':' << line << "] ";
+      }
 #else
       struct timeval tv;
       gettimeofday(&tv, NULL);
       struct tm tm_time;
       gmtime_r(((time_t*)&(tv.tv_sec)), &tm_time);
-      stream_ << level_name_[std::min(level, (uint32_t)Level::kINFO)]
-              << std::setfill('0') << std::setw(2) << (tm_time.tm_mon + 1)
-              << std::setw(2) << tm_time.tm_mday << ' ' << std::setw(2)
-              << tm_time.tm_hour << ':' << std::setw(2) << tm_time.tm_min << ':'
-              << std::setw(2) << tm_time.tm_sec << '.' << std::setw(6)
-              << tv.tv_usec << ' ' << static_cast<uint32_t>(getpid()) << ' '
-              << path << ':' << line << "] ";
+      {
+        std::lock_guard<std::mutex> lk(gLogger_.GetMutex());
+        stream_ << level_name_[std::min(level, (uint32_t)Level::kINFO)]
+                << std::setfill('0') << std::setw(2) << (tm_time.tm_mon + 1)
+                << std::setw(2) << tm_time.tm_mday << ' ' << std::setw(2)
+                << tm_time.tm_hour << ':' << std::setw(2) << tm_time.tm_min << ':'
+                << std::setw(2) << tm_time.tm_sec << '.' << std::setw(6)
+                << tv.tv_usec << ' ' << static_cast<uint32_t>(getpid()) << ' '
+                << path << ':' << line << "] ";
+      }
 #endif
       break;
     }
@@ -112,27 +118,33 @@ LogMessage::LogMessage(const char* file, int line, uint32_t level)
 #ifdef _WIN32
       SYSTEMTIME system_time;
       GetSystemTime(&system_time);
-      stream_ << system_time.wYear << '-' << std::setfill('0') << std::setw(2)
-              << system_time.wMonth << '-' << std::setw(2) << system_time.wDay
-              << 'T' << std::setw(2) << system_time.wHour << ':' << std::setw(2)
-              << system_time.wMinute << ':' << std::setw(2)
-              << system_time.wSecond << "Z "
-              << level_name_[std::min(level, (uint32_t)Level::kINFO)] << ' '
-              << static_cast<uint32_t>(GetCurrentProcessId()) << ' ' << path
-              << ':' << line << "] ";
+      {
+        std::lock_guard<std::mutex> lk(gLogger_.GetMutex());
+        stream_ << system_time.wYear << '-' << std::setfill('0') << std::setw(2)
+                << system_time.wMonth << '-' << std::setw(2) << system_time.wDay
+                << 'T' << std::setw(2) << system_time.wHour << ':' << std::setw(2)
+                << system_time.wMinute << ':' << std::setw(2)
+                << system_time.wSecond << "Z "
+                << level_name_[std::min(level, (uint32_t)Level::kINFO)] << ' '
+                << static_cast<uint32_t>(GetCurrentProcessId()) << ' ' << path
+                << ':' << line << "] ";
+      }
 #else
       struct timeval tv;
       gettimeofday(&tv, NULL);
       struct tm tm_time;
       gmtime_r(((time_t*)&(tv.tv_sec)), &tm_time);
-      stream_ << (tm_time.tm_year + 1900) << '-' << std::setfill('0')
-              << std::setw(2) << (tm_time.tm_mon + 1) << '-' << std::setw(2)
-              << tm_time.tm_mday << 'T' << std::setw(2) << tm_time.tm_hour
-              << ':' << std::setw(2) << tm_time.tm_min << ':' << std::setw(2)
-              << tm_time.tm_sec << "Z "
-              << level_name_[std::min(level, (uint32_t)Level::kINFO)] << ' '
-              << static_cast<uint32_t>(getpid()) << ' ' << path << ':' << line
-              << "] ";
+      {
+        std::lock_guard<std::mutex> lk(gLogger_.GetMutex());
+        stream_ << (tm_time.tm_year + 1900) << '-' << std::setfill('0')
+                << std::setw(2) << (tm_time.tm_mon + 1) << '-' << std::setw(2)
+                << tm_time.tm_mday << 'T' << std::setw(2) << tm_time.tm_hour
+                << ':' << std::setw(2) << tm_time.tm_min << ':' << std::setw(2)
+                << tm_time.tm_sec << "Z "
+                << level_name_[std::min(level, (uint32_t)Level::kINFO)] << ' '
+                << static_cast<uint32_t>(getpid()) << ' ' << path << ':' << line
+                << "] ";
+      }
 #endif
       break;
     }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -89,9 +89,10 @@ LogMessage::LogMessage(const char* file, int line, uint32_t level)
         stream_ << level_name_[std::min(level, (uint32_t)Level::kINFO)]
                 << std::setfill('0') << std::setw(2) << system_time.wMonth
                 << std::setw(2) << system_time.wDay << ' ' << std::setw(2)
-                << system_time.wHour << ':' << std::setw(2) << system_time.wMinute
-                << ':' << std::setw(2) << system_time.wSecond << '.'
-                << std::setw(6) << system_time.wMilliseconds * 1000 << ' '
+                << system_time.wHour << ':' << std::setw(2)
+                << system_time.wMinute << ':' << std::setw(2)
+                << system_time.wSecond << '.' << std::setw(6)
+                << system_time.wMilliseconds * 1000 << ' '
                 << static_cast<uint32_t>(GetCurrentProcessId()) << ' ' << path
                 << ':' << line << "] ";
       }
@@ -105,8 +106,8 @@ LogMessage::LogMessage(const char* file, int line, uint32_t level)
         stream_ << level_name_[std::min(level, (uint32_t)Level::kINFO)]
                 << std::setfill('0') << std::setw(2) << (tm_time.tm_mon + 1)
                 << std::setw(2) << tm_time.tm_mday << ' ' << std::setw(2)
-                << tm_time.tm_hour << ':' << std::setw(2) << tm_time.tm_min << ':'
-                << std::setw(2) << tm_time.tm_sec << '.' << std::setw(6)
+                << tm_time.tm_hour << ':' << std::setw(2) << tm_time.tm_min
+                << ':' << std::setw(2) << tm_time.tm_sec << '.' << std::setw(6)
                 << tv.tv_usec << ' ' << static_cast<uint32_t>(getpid()) << ' '
                 << path << ':' << line << "] ";
       }
@@ -122,8 +123,8 @@ LogMessage::LogMessage(const char* file, int line, uint32_t level)
         std::lock_guard<std::mutex> lk(gLogger_.GetMutex());
         stream_ << system_time.wYear << '-' << std::setfill('0') << std::setw(2)
                 << system_time.wMonth << '-' << std::setw(2) << system_time.wDay
-                << 'T' << std::setw(2) << system_time.wHour << ':' << std::setw(2)
-                << system_time.wMinute << ':' << std::setw(2)
+                << 'T' << std::setw(2) << system_time.wHour << ':'
+                << std::setw(2) << system_time.wMinute << ':' << std::setw(2)
                 << system_time.wSecond << "Z "
                 << level_name_[std::min(level, (uint32_t)Level::kINFO)] << ' '
                 << static_cast<uint32_t>(GetCurrentProcessId()) << ' ' << path


### PR DESCRIPTION
Our logger uses std::stringstream, which is not thread-safe. Adding a mutex should remove possible undefined behavior (e.g. overlapping logs and segfaults).

Per the C++ 17 standard, "Concurrent access to a stream object (30.8, 30.9), stream buffer object (30.6), or C Library stream (30.12) by multiple threads may result in a data race (6.8.2) unless otherwise specified (30.4). [ Note: Data races result in undefined behavior (6.8.2). — end note ] – [iostreams.threadsafety]." (Source: https://berthub.eu/articles/posts/iostreams-unexpected/; in addition, there is [this 2020 copy of C++ standard under 29.2.3](https://isocpp.org/files/papers/N4860.pdf)).