### PR TITLE
Add runtime to model configuration

### DIFF
--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1,4 +1,4 @@
-// Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1842,6 +1842,12 @@ message ModelConfig
   //@@
   string backend = 17;
 
+  //@@  .. cpp:var:: string runtime
+  //@@
+  //@@     The name of the backend library file used by the model.
+  //@@
+  string runtime = 25;
+
   //@@  .. cpp:var:: ModelVersionPolicy version_policy
   //@@
   //@@     Policy indicating which version(s) of the model will be served.


### PR DESCRIPTION
Related PRs:
* https://github.com/triton-inference-server/server/pull/6518
* https://github.com/triton-inference-server/core/pull/285
* https://github.com/triton-inference-server/backend/pull/94
* https://github.com/triton-inference-server/pytorch_backend/pull/117

The user can now choose the "runtime" for each model, for example:
```
runtime: "libtriton_tensorrt.so"
```
```
runtime: "model.py"
```