### PR TITLE
Add cancellation into response statistics

### DIFF
--- a/protobuf/grpc_service.proto
+++ b/protobuf/grpc_service.proto
@@ -1050,6 +1050,13 @@ message InferResponseStatistics
   //@@     The count and cumulative duration for empty responses.
   //@@
   StatisticDuration empty_response = 5;
+
+  //@@  .. cpp:var:: StatisticDuration cancel
+  //@@
+  //@@     The count and cumulative duration, for cleaning up resources held by
+  //@@     a cancelled request, for cancelled responses.
+  //@@
+  StatisticDuration cancel = 6;
 }
 
 //@@


### PR DESCRIPTION
Related PRs:
- https://github.com/triton-inference-server/server/pull/6904
- https://github.com/triton-inference-server/core/pull/329
- https://github.com/triton-inference-server/square_backend/pull/17

Add cancellation statistics field into response statistics.