### PR TITLE
Update default log formats to escape messages using JSON encoding rules

### DIFF
--- a/include/triton/common/error.h
+++ b/include/triton/common/error.h
@@ -36,7 +36,7 @@ namespace triton { namespace common {
 //
 class Error {
  public:
-  enum class Code {
+  enum class Code : uint8_t {
     SUCCESS,
     UNKNOWN,
     INTERNAL,

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -271,7 +271,7 @@ class LogMessage {
   } while (false)
 
 #define LOG_SERVER_MESSAGE_WARNING_FL(                                     \
-    FN, LN, HEADINER, SERVER_MESSAGE_PTR, SIZE)                            \
+    FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE)                             \
                                                                            \
   do {                                                                     \
     if (LOG_WARNING_IS_ON)                                                 \

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -48,6 +48,7 @@
 
 namespace triton { namespace common {
 
+
 // Global logger for messages. Controls how log messages are reported.
 class Logger {
  public:
@@ -56,6 +57,9 @@ class Logger {
 
   // Log levels.
   enum Level { kERROR = 0, kWARNING = 1, kINFO = 2, kEND };
+
+  inline static const std::array<const char*, Level::kEND> LEVEL_NAMES{
+      "E", "W", "I"};
 
   Logger();
 
@@ -129,9 +133,11 @@ class Logger {
   // Flush the log.
   void Flush();
 
-  static const std::array<const char*, Level::kEND> LEVEL_NAMES;
 
  private:
+  inline static const char* ESCAPE_ENVIRONMENT_VARIABLE =
+      "TRITON_SERVER_ESCAPE_LOG_MESSAGES";
+
   bool escape_log_messages_;
   std::vector<bool> enables_;
   uint32_t vlevel_;

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -133,11 +133,9 @@ class Logger {
   // Flush the log.
   void Flush();
 
-
  private:
   inline static const char* ESCAPE_ENVIRONMENT_VARIABLE =
       "TRITON_SERVER_ESCAPE_LOG_MESSAGES";
-
   bool escape_log_messages_;
   std::vector<bool> enables_;
   uint32_t vlevel_;

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -266,7 +266,7 @@ class LogMessage {
       triton::common::LogMessage(                                             \
           (char*)(FN), LN, triton::common::Logger::Level::kINFO, false)       \
               .stream()                                                       \
-          << HEADING << '\n'                                                  \
+          << triton::common::TritonJson::EscapeString(HEADING) << '\n'        \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                         \
   } while (false)
 
@@ -278,7 +278,7 @@ class LogMessage {
       triton::common::LogMessage(                                          \
           (char*)(FN), LN, triton::common::Logger::Level::kWARNING, false) \
               .stream()                                                    \
-          << HEADING << '\n'                                               \
+          << triton::common::TritonJson::EscapeString(HEADING) << '\n'     \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                      \
   } while (false)
 
@@ -289,7 +289,7 @@ class LogMessage {
       triton::common::LogMessage(                                              \
           (char*)(FN), LN, triton::common::Logger::Level::kERROR, false)       \
               .stream()                                                        \
-          << HEADING << '\n'                                                   \
+          << triton::common::TritonJson::EscapeString(HEADING) << '\n'         \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                          \
   } while (false)
 
@@ -301,7 +301,7 @@ class LogMessage {
       triton::common::LogMessage(                                       \
           (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
               .stream()                                                 \
-          << HEADING << '\n'                                            \
+          << triton::common::TritonJson::EscapeString(HEADING) << '\n'  \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                   \
   } while (false)
 
@@ -351,7 +351,7 @@ class LogMessage {
       triton::common::LogMessage(                                          \
           __FILE__, __LINE__, triton::common::Logger::Level::kINFO, false) \
               .stream()                                                    \
-          << HEADING << '\n'                                               \
+          << triton::common::TritonJson::EscapeString(HEADING) << '\n'     \
           << PB_MESSAGE.DebugString();                                     \
   } while (false)
 

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -74,7 +74,7 @@ class Logger {
   // Whether to escape log messages
   // using JSON string escaping rules.
   // Default is true but can be disabled via an environment variable
-  // TRITONSERVER_ESCAPE_LOG_MESSAGES
+  // TRITON_SERVER_ESCAPE_LOG_MESSAGES
   bool EscapeLogMessages() const { return escape_log_messages_; };
 
   // Get the logging format.

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -160,24 +160,18 @@ extern Logger gLogger_;
 // A log message.
 class LogMessage {
  public:
-  LogMessage(const char* file, int line, Logger::Level level)
+  LogMessage(
+      const char* file, int line, Logger::Level level,
+      const char* heading = nullptr,
+      bool escape_log_messages = gLogger_.EscapeLogMessages())
       : path_(file), line_(line), level_(level), pid_(GetProcessId()),
-        heading_(nullptr), escape_log_messages_(gLogger_.EscapeLogMessages())
+        heading_(heading), escape_log_messages_(escape_log_messages)
   {
     SetTimestamp();
     size_t path_start = path_.rfind('/');
     if (path_start != std::string::npos) {
       path_ = path_.substr(path_start + 1, std::string::npos);
     }
-  }
-
-  LogMessage(
-      const char* file, int line, Logger::Level level, const char* heading,
-      bool escape_log_messages)
-      : LogMessage(file, line, level)
-  {
-    escape_log_messages_ = escape_log_messages;
-    heading_ = heading;
   }
 
   ~LogMessage();

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -266,7 +266,7 @@ class LogMessage {
       triton::common::LogMessage(                                             \
           (char*)(FN), LN, triton::common::Logger::Level::kINFO, false)       \
               .stream()                                                       \
-          << triton::common::TritonJson::EscapeString(HEADING) << '\n'        \
+          << HEADING << '\n'                                                  \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                         \
   } while (false)
 
@@ -278,7 +278,7 @@ class LogMessage {
       triton::common::LogMessage(                                          \
           (char*)(FN), LN, triton::common::Logger::Level::kWARNING, false) \
               .stream()                                                    \
-          << triton::common::TritonJson::EscapeString(HEADING) << '\n'     \
+          << HEADING << '\n'                                               \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                      \
   } while (false)
 
@@ -289,7 +289,7 @@ class LogMessage {
       triton::common::LogMessage(                                              \
           (char*)(FN), LN, triton::common::Logger::Level::kERROR, false)       \
               .stream()                                                        \
-          << triton::common::TritonJson::EscapeString(HEADING) << '\n'         \
+          << HEADING << '\n'                                                   \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                          \
   } while (false)
 
@@ -301,7 +301,7 @@ class LogMessage {
       triton::common::LogMessage(                                       \
           (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
               .stream()                                                 \
-          << triton::common::TritonJson::EscapeString(HEADING) << '\n'  \
+          << HEADING << '\n'                                            \
           << std::string({SERVER_MESSAGE_PTR, SIZE});                   \
   } while (false)
 
@@ -351,7 +351,7 @@ class LogMessage {
       triton::common::LogMessage(                                          \
           __FILE__, __LINE__, triton::common::Logger::Level::kINFO, false) \
               .stream()                                                    \
-          << triton::common::TritonJson::EscapeString(HEADING) << '\n'     \
+          << HEADING << '\n'                                               \
           << PB_MESSAGE.DebugString();                                     \
   } while (false)
 

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -302,7 +302,7 @@ class LogMessage {
           << PB_MESSAGE.DebugString();                                     \
   } while (false)
 
-// Macros for loggine errors
+// Macros for logging errors
 #define LOG_STATUS_ERROR(X, MSG)                         \
   do {                                                   \
     const Status& status__ = (X);                        \

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -77,8 +77,12 @@ class Logger {
 
   // Whether to escape log messages
   // using JSON string escaping rules.
-  // Default is true but can be disabled via an environment variable
-  // TRITON_SERVER_ESCAPE_LOG_MESSAGES
+  // Default is true but can be disabled by setting
+  // the following environment variable to '0'.
+  // If the variable is unset or set to any value !='0'
+  // log messages will be escaped
+  //
+  // TRITON_SERVER_ESCAPE_LOG_MESSAGES=0
   bool EscapeLogMessages() const { return escape_log_messages_; };
 
   // Get the logging format.

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -55,7 +55,7 @@ class Logger {
   enum class Format { kDEFAULT, kISO8601 };
 
   // Log levels.
-  enum Level { kERROR = 0, kWARNING = 1, kINFO = 2 };
+  enum Level { kERROR = 0, kWARNING = 1, kINFO = 2, kEND };
 
   Logger();
 
@@ -254,6 +254,51 @@ class LogMessage {
       (char*)(FN), LN, triton::common::Logger::Level::kINFO) \
       .stream()
 
+#define LOG_JSON_INFO_FL(FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)         \
+                                                                        \
+  do {                                                                  \
+    if (LOG_INFO_IS_ON)                                                 \
+      triton::common::LogMessage(                                       \
+          (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
+              .stream()                                                 \
+          << PREAMBLE << '\n'                                           \
+          << std::string({JSON_CHAR_PTR, SIZE});                        \
+  } while (false)
+
+#define LOG_JSON_WARNING_FL(FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)         \
+                                                                           \
+  do {                                                                     \
+    if (LOG_WARNING_IS_ON)                                                 \
+      triton::common::LogMessage(                                          \
+          (char*)(FN), LN, triton::common::Logger::Level::kWARNING, false) \
+              .stream()                                                    \
+          << PREAMBLE << '\n'                                              \
+          << std::string({JSON_CHAR_PTR, SIZE});                           \
+  } while (false)
+
+#define LOG_JSON_ERROR_FL(FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)         \
+                                                                         \
+  do {                                                                   \
+    if (LOG_ERROR_IS_ON)                                                 \
+      triton::common::LogMessage(                                        \
+          (char*)(FN), LN, triton::common::Logger::Level::kERROR, false) \
+              .stream()                                                  \
+          << PREAMBLE << '\n'                                            \
+          << std::string({JSON_CHAR_PTR, SIZE});                         \
+  } while (false)
+
+#define LOG_JSON_VERBOSE_FL(L, FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)   \
+                                                                        \
+  do {                                                                  \
+    if (LOG_VERBOSE_IS_ON(L))                                           \
+      triton::common::LogMessage(                                       \
+          (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
+              .stream()                                                 \
+          << PREAMBLE << '\n'                                           \
+          << std::string({JSON_CHAR_PTR, SIZE});                        \
+  } while (false)
+
+
 // Macros that use current filename and line number.
 #define LOG_INFO LOG_INFO_FL(__FILE__, __LINE__)
 #define LOG_WARNING LOG_WARNING_FL(__FILE__, __LINE__)
@@ -270,6 +315,16 @@ class LogMessage {
           << TABLE.PrintTable();                                           \
   } while (false)
 
+#define LOG_PROTOBUF_VERBOSE(L, PREAMBLE, PB_MESSAGE)                      \
+                                                                           \
+  do {                                                                     \
+    if (LOG_VERBOSE_IS_ON(L))                                              \
+      triton::common::LogMessage(                                          \
+          __FILE__, __LINE__, triton::common::Logger::Level::kINFO, false) \
+              .stream()                                                    \
+          << PREAMBLE << '\n'                                              \
+          << PB_MESSAGE.DebugString();                                     \
+  } while (false)
 
 #define LOG_TABLE_INFO(TABLE)                                              \
   do {                                                                     \

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -129,7 +129,7 @@ class Logger {
   // Flush the log.
   void Flush();
 
-  static const std::array<const char*, Level::kINFO + 1> LEVEL_NAMES;
+  static const std::array<const char*, Level::kEND> LEVEL_NAMES;
 
  private:
   bool escape_log_messages_;

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -70,7 +70,6 @@ class LogMessage {
 
  private:
   static const std::array<const char*, Level::kINFO + 1> LEVEL_NAMES_;
-  static const std::vector<char> level_name_;
   std::string path_;
   const int line_;
   const uint32_t level_;

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -254,57 +254,6 @@ class LogMessage {
       (char*)(FN), LN, triton::common::Logger::Level::kINFO) \
       .stream()
 
-// Macros for use with TRITONSERVER_Message objects
-//
-// Data is assumed to be serialized and escaped already
-// Message objects are logged without further escaping
-
-#define LOG_SERVER_MESSAGE_INFO_FL(FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE) \
-                                                                              \
-  do {                                                                        \
-    if (LOG_INFO_IS_ON)                                                       \
-      triton::common::LogMessage(                                             \
-          (char*)(FN), LN, triton::common::Logger::Level::kINFO, false)       \
-              .stream()                                                       \
-          << HEADING << '\n'                                                  \
-          << std::string({SERVER_MESSAGE_PTR, SIZE});                         \
-  } while (false)
-
-#define LOG_SERVER_MESSAGE_WARNING_FL(                                     \
-    FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE)                             \
-                                                                           \
-  do {                                                                     \
-    if (LOG_WARNING_IS_ON)                                                 \
-      triton::common::LogMessage(                                          \
-          (char*)(FN), LN, triton::common::Logger::Level::kWARNING, false) \
-              .stream()                                                    \
-          << HEADING << '\n'                                               \
-          << std::string({SERVER_MESSAGE_PTR, SIZE});                      \
-  } while (false)
-
-#define LOG_SERVER_MESSAGE_ERROR_FL(FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE) \
-                                                                               \
-  do {                                                                         \
-    if (LOG_ERROR_IS_ON)                                                       \
-      triton::common::LogMessage(                                              \
-          (char*)(FN), LN, triton::common::Logger::Level::kERROR, false)       \
-              .stream()                                                        \
-          << HEADING << '\n'                                                   \
-          << std::string({SERVER_MESSAGE_PTR, SIZE});                          \
-  } while (false)
-
-#define LOG_SERVER_MESSAGE_VERBOSE_FL(                                  \
-    L, FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE)                       \
-                                                                        \
-  do {                                                                  \
-    if (LOG_VERBOSE_IS_ON(L))                                           \
-      triton::common::LogMessage(                                       \
-          (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
-              .stream()                                                 \
-          << HEADING << '\n'                                            \
-          << std::string({SERVER_MESSAGE_PTR, SIZE});                   \
-  } while (false)
-
 // Macros that use current filename and line number.
 #define LOG_INFO LOG_INFO_FL(__FILE__, __LINE__)
 #define LOG_WARNING LOG_WARNING_FL(__FILE__, __LINE__)
@@ -317,7 +266,6 @@ class LogMessage {
 // and not for use with client input.
 //
 // Tables are printed without escaping
-
 #define LOG_TABLE_VERBOSE(L, TABLE)                                        \
                                                                            \
   do {                                                                     \
@@ -343,7 +291,6 @@ class LogMessage {
 // Data is serialized via DebugString()
 //
 // Data is printed without further escaping
-
 #define LOG_PROTOBUF_VERBOSE(L, HEADING, PB_MESSAGE)                       \
                                                                            \
   do {                                                                     \
@@ -355,6 +302,7 @@ class LogMessage {
           << PB_MESSAGE.DebugString();                                     \
   } while (false)
 
+// Macros for loggine errors
 #define LOG_STATUS_ERROR(X, MSG)                         \
   do {                                                   \
     const Status& status__ = (X);                        \

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -254,56 +254,69 @@ class LogMessage {
       (char*)(FN), LN, triton::common::Logger::Level::kINFO) \
       .stream()
 
-#define LOG_JSON_INFO_FL(FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)         \
-                                                                        \
-  do {                                                                  \
-    if (LOG_INFO_IS_ON)                                                 \
-      triton::common::LogMessage(                                       \
-          (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
-              .stream()                                                 \
-          << PREAMBLE << '\n'                                           \
-          << std::string({JSON_CHAR_PTR, SIZE});                        \
+// Macros for use with TRITONSERVER_Message objects
+//
+// Data is assumed to be serialized and escaped already
+// Message objects are logged without further escaping
+
+#define LOG_SERVER_MESSAGE_INFO_FL(FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE) \
+                                                                              \
+  do {                                                                        \
+    if (LOG_INFO_IS_ON)                                                       \
+      triton::common::LogMessage(                                             \
+          (char*)(FN), LN, triton::common::Logger::Level::kINFO, false)       \
+              .stream()                                                       \
+          << HEADING << '\n'                                                  \
+          << std::string({SERVER_MESSAGE_PTR, SIZE});                         \
   } while (false)
 
-#define LOG_JSON_WARNING_FL(FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)         \
+#define LOG_SERVER_MESSAGE_WARNING_FL(                                     \
+    FN, LN, HEADINER, SERVER_MESSAGE_PTR, SIZE)                            \
                                                                            \
   do {                                                                     \
     if (LOG_WARNING_IS_ON)                                                 \
       triton::common::LogMessage(                                          \
           (char*)(FN), LN, triton::common::Logger::Level::kWARNING, false) \
               .stream()                                                    \
-          << PREAMBLE << '\n'                                              \
-          << std::string({JSON_CHAR_PTR, SIZE});                           \
+          << HEADING << '\n'                                               \
+          << std::string({SERVER_MESSAGE_PTR, SIZE});                      \
   } while (false)
 
-#define LOG_JSON_ERROR_FL(FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)         \
-                                                                         \
-  do {                                                                   \
-    if (LOG_ERROR_IS_ON)                                                 \
-      triton::common::LogMessage(                                        \
-          (char*)(FN), LN, triton::common::Logger::Level::kERROR, false) \
-              .stream()                                                  \
-          << PREAMBLE << '\n'                                            \
-          << std::string({JSON_CHAR_PTR, SIZE});                         \
+#define LOG_SERVER_MESSAGE_ERROR_FL(FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE) \
+                                                                               \
+  do {                                                                         \
+    if (LOG_ERROR_IS_ON)                                                       \
+      triton::common::LogMessage(                                              \
+          (char*)(FN), LN, triton::common::Logger::Level::kERROR, false)       \
+              .stream()                                                        \
+          << HEADING << '\n'                                                   \
+          << std::string({SERVER_MESSAGE_PTR, SIZE});                          \
   } while (false)
 
-#define LOG_JSON_VERBOSE_FL(L, FN, LN, PREAMBLE, JSON_CHAR_PTR, SIZE)   \
+#define LOG_SERVER_MESSAGE_VERBOSE_FL(                                  \
+    L, FN, LN, HEADING, SERVER_MESSAGE_PTR, SIZE)                       \
                                                                         \
   do {                                                                  \
     if (LOG_VERBOSE_IS_ON(L))                                           \
       triton::common::LogMessage(                                       \
           (char*)(FN), LN, triton::common::Logger::Level::kINFO, false) \
               .stream()                                                 \
-          << PREAMBLE << '\n'                                           \
-          << std::string({JSON_CHAR_PTR, SIZE});                        \
+          << HEADING << '\n'                                            \
+          << std::string({SERVER_MESSAGE_PTR, SIZE});                   \
   } while (false)
-
 
 // Macros that use current filename and line number.
 #define LOG_INFO LOG_INFO_FL(__FILE__, __LINE__)
 #define LOG_WARNING LOG_WARNING_FL(__FILE__, __LINE__)
 #define LOG_ERROR LOG_ERROR_FL(__FILE__, __LINE__)
 #define LOG_VERBOSE(L) LOG_VERBOSE_FL(L, __FILE__, __LINE__)
+
+// Macros for use with triton::common::table_printer objects
+//
+// Data is assumed to be server / backend generated
+// and not for use with client input.
+//
+// Tables are printed without escaping
 
 #define LOG_TABLE_VERBOSE(L, TABLE)                                        \
                                                                            \
@@ -315,17 +328,6 @@ class LogMessage {
           << TABLE.PrintTable();                                           \
   } while (false)
 
-#define LOG_PROTOBUF_VERBOSE(L, PREAMBLE, PB_MESSAGE)                      \
-                                                                           \
-  do {                                                                     \
-    if (LOG_VERBOSE_IS_ON(L))                                              \
-      triton::common::LogMessage(                                          \
-          __FILE__, __LINE__, triton::common::Logger::Level::kINFO, false) \
-              .stream()                                                    \
-          << PREAMBLE << '\n'                                              \
-          << PB_MESSAGE.DebugString();                                     \
-  } while (false)
-
 #define LOG_TABLE_INFO(TABLE)                                              \
   do {                                                                     \
     if (LOG_INFO_IS_ON)                                                    \
@@ -333,6 +335,24 @@ class LogMessage {
           __FILE__, __LINE__, triton::common::Logger::Level::kINFO, false) \
               .stream()                                                    \
           << TABLE.PrintTable();                                           \
+  } while (false)
+
+
+// Macros for use with protobuf messages
+//
+// Data is serialized via DebugString()
+//
+// Data is printed without further escaping
+
+#define LOG_PROTOBUF_VERBOSE(L, HEADING, PB_MESSAGE)                       \
+                                                                           \
+  do {                                                                     \
+    if (LOG_VERBOSE_IS_ON(L))                                              \
+      triton::common::LogMessage(                                          \
+          __FILE__, __LINE__, triton::common::Logger::Level::kINFO, false) \
+              .stream()                                                    \
+          << HEADING << '\n'                                               \
+          << PB_MESSAGE.DebugString();                                     \
   } while (false)
 
 #define LOG_STATUS_ERROR(X, MSG)                         \

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -310,7 +310,6 @@ class LogMessage {
 //
 // Data is printed without further escaping
 #define LOG_PROTOBUF_VERBOSE(L, HEADING, PB_MESSAGE)                         \
-                                                                             \
   do {                                                                       \
     if (LOG_VERBOSE_IS_ON(L))                                                \
       triton::common::LogMessage(                                            \

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -110,11 +110,10 @@ class TritonJson {
   };
 
   //
-  // Utility to return an escaped version of the
-  // input string
-  //
+  // Utility to serialize input string
+  // as a JSON string value
 
-  static std::string EscapeString(const std::string& input)
+  static std::string SerializeString(const std::string& input)
   {
     WriteBuffer writebuffer;
     const unsigned int writeFlags = rapidjson::kWriteNanAndInfFlag;

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -110,6 +110,11 @@ class TritonJson {
     std::string buffer_;
   };
 
+  //
+  // Utility to return an escaped version of the
+  // input string
+  //
+
   static std::string EscapeString(const std::string& input)
   {
     WriteBuffer writebuffer;
@@ -119,7 +124,9 @@ class TritonJson {
         WriteBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>,
         rapidjson::CrtAllocator, writeFlags>
         writer(writebuffer);
-    writer.String(input.c_str());
+    if (RAPIDJSON_UNLIKELY(!writer.String(input.c_str()))) {
+      return "Error Escaping String";
+    }
     return writebuffer.Contents();
   }
 

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -123,7 +123,7 @@ class TritonJson {
         rapidjson::CrtAllocator, writeFlags>
         writer(writebuffer);
     if (RAPIDJSON_UNLIKELY(!writer.String(input.c_str()))) {
-      return "Error Escaping String";
+      return "Error Serializing String";
     }
     return writebuffer.Contents();
   }

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+
 #ifdef _WIN32
 // Remove GetObject definition from windows.h, which prevents calls to
 // RapidJSON's GetObject.
@@ -108,6 +109,19 @@ class TritonJson {
    private:
     std::string buffer_;
   };
+
+  static std::string EscapeString(const std::string& input)
+  {
+    WriteBuffer writebuffer;
+    const unsigned int writeFlags = rapidjson::kWriteNanAndInfFlag;
+    // Provide default template arguments to pass writeFlags
+    rapidjson::Writer<
+        WriteBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>,
+        rapidjson::CrtAllocator, writeFlags>
+        writer(writebuffer);
+    writer.String(input.c_str());
+    return writebuffer.Contents();
+  }
 
   //
   // Value representing the entire document or an element within a

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -25,7 +25,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-
 #ifdef _WIN32
 // Remove GetObject definition from windows.h, which prevents calls to
 // RapidJSON's GetObject.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   PRIVATE
+    ${RAPIDJSON_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -90,7 +90,7 @@ LogMessage::LogTimestamp(std::stringstream& stream)
              << timestamp_.wMonth << '-' << std::setw(2) << timestamp_.wDay
              << 'T' << std::setw(2) << timestamp_.wHour << ':' << std::setw(2)
              << timestamp_.wMinute << ':' << std::setw(2) << timestamp_.wSecond
-             << '.' << std::setw(6) << timestamp_.wMilliseconds * 1000 << "Z";
+             << "Z";
       break;
     }
   }
@@ -116,8 +116,7 @@ LogMessage::LogTimestamp(std::stringstream& stream)
              << std::setw(2) << (tm_time.tm_mon + 1) << '-' << std::setw(2)
              << tm_time.tm_mday << 'T' << std::setw(2) << tm_time.tm_hour << ':'
              << std::setw(2) << tm_time.tm_min << ':' << std::setw(2)
-             << tm_time.tm_sec << '.' << std::setw(6) << timestamp_.tv_usec
-             << "Z";
+             << tm_time.tm_sec << "Z";
       break;
     }
   }
@@ -132,13 +131,13 @@ LogMessage::LogPreamble(std::stringstream& stream)
     case Logger::Format::kDEFAULT: {
       stream << Logger::LEVEL_NAMES[level_];
       LogTimestamp(stream);
-      stream << ' ' << pid_ << " [" << path_ << ':' << line_ << "] ";
+      stream << ' ' << pid_ << ' ' << path_ << ':' << line_ << "] ";
 
       break;
     }
     case Logger::Format::kISO8601: {
       LogTimestamp(stream);
-      stream << " " << Logger::LEVEL_NAMES[level_] << ' ' << pid_ << " ["
+      stream << " " << Logger::LEVEL_NAMES[level_] << ' ' << pid_ << ' '
              << path_ << ':' << line_ << "] ";
       break;
     }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -145,12 +145,12 @@ LogMessage::~LogMessage()
 {
   std::stringstream log_record;
   LogPreamble(log_record);
-  std::string escaped_message = escape_log_messages_
-                                    ? TritonJson::EscapeString(message_.str())
-                                    : message_.str();
+  std::string escaped_message =
+      escape_log_messages_ ? TritonJson::SerializeString(message_.str())
+                           : message_.str();
   if (heading_ != nullptr) {
     std::string escaped_heading = gLogger_.EscapeLogMessages()
-                                      ? TritonJson::EscapeString(heading_)
+                                      ? TritonJson::SerializeString(heading_)
                                       : heading_;
     log_record << escaped_heading << '\n';
   }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -125,7 +125,7 @@ LogMessage::LogPreamble(std::stringstream& stream)
 {
   switch (gLogger_.LogFormat()) {
     case Logger::Format::kDEFAULT: {
-      stream << Logger::LEVEL_NAMES[level_];
+      stream << Logger::LEVEL_NAMES[static_cast<uint8_t>(level_)];
       LogTimestamp(stream);
       stream << ' ' << pid_ << ' ' << path_ << ':' << line_ << "] ";
 
@@ -133,8 +133,8 @@ LogMessage::LogPreamble(std::stringstream& stream)
     }
     case Logger::Format::kISO8601: {
       LogTimestamp(stream);
-      stream << " " << Logger::LEVEL_NAMES[level_] << ' ' << pid_ << ' '
-             << path_ << ':' << line_ << "] ";
+      stream << " " << Logger::LEVEL_NAMES[static_cast<uint8_t>(level_)] << ' '
+             << pid_ << ' ' << path_ << ':' << line_ << "] ";
       break;
     }
   }
@@ -148,6 +148,12 @@ LogMessage::~LogMessage()
   std::string escaped_message = escape_log_messages_
                                     ? TritonJson::EscapeString(message_.str())
                                     : message_.str();
+  if (heading_ != nullptr) {
+    std::string escaped_heading = gLogger_.EscapeLogMessages()
+                                      ? TritonJson::EscapeString(heading_)
+                                      : heading_;
+    preamble << escaped_heading << '\n';
+  }
   preamble << escaped_message;
   gLogger_.Log(preamble.str());
 }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -47,8 +47,7 @@ Logger::Logger()
     : enables_{true, true, true}, vlevel_(0), format_(Format::kDEFAULT)
 {
   const char* value = std::getenv(Logger::ESCAPE_ENVIRONMENT_VARIABLE);
-  escape_log_messages_ =
-      (value && std::strcmp(value, "FALSE") == 0) ? false : true;
+  escape_log_messages_ = (value && std::strcmp(value, "0") == 0) ? false : true;
 }
 
 void

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -75,7 +75,7 @@ Logger::Flush()
 }
 
 const std::array<const char*, LogMessage::Level::kINFO + 1>
-    LogMessage::LEVEL_NAMES_{"Error", "Warning", "Info"};
+    LogMessage::LEVEL_NAMES_{"ERROR", "WARNING", "INFO"};
 const std::vector<char> LogMessage::level_name_{'E', 'W', 'I'};
 
 #ifdef _WIN32
@@ -189,11 +189,14 @@ LogMessage::~LogMessage()
     case Logger::Format::kJSONL: {
       TritonJson::Value logMessage(TritonJson::ValueType::OBJECT);
       TritonJson::WriteBuffer buffer;
+      std::stringstream timestamp;
+      LogTimestamp(timestamp);
       logMessage.AddString("file", path_);
       logMessage.AddInt("line", line_);
       logMessage.AddString("level", LEVEL_NAMES_[level_]);
-      logMessage.AddInt("pid", pid_);
+      logMessage.AddInt("process_id", pid_);
       logMessage.AddString("message", message_.str());
+      logMessage.AddString("timestamp", timestamp.str());
       logMessage.Write(&buffer);
       gLogger_.Log(buffer.Contents());
       break;

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -46,7 +46,7 @@ Logger gLogger_;
 Logger::Logger()
     : enables_{true, true, true}, vlevel_(0), format_(Format::kDEFAULT)
 {
-  const char* value = std::getenv("TRITONSERVER_ESCAPE_LOG_MESSAGES");
+  const char* value = std::getenv("TRITON_SERVER_ESCAPE_LOG_MESSAGES");
   escape_log_messages_ =
       (value && std::strcmp(value, "FALSE") == 0) ? false : true;
 }
@@ -68,7 +68,7 @@ Logger::Flush()
   std::cerr << std::flush;
 }
 
-const std::array<const char*, Logger::Level::kINFO + 1> Logger::LEVEL_NAMES{
+const std::array<const char*, Logger::Level::kEND> Logger::LEVEL_NAMES{
     "E", "W", "I"};
 
 #ifdef _WIN32

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -143,8 +143,8 @@ LogMessage::LogPreamble(std::stringstream& stream)
 
 LogMessage::~LogMessage()
 {
-  std::stringstream preamble;
-  LogPreamble(preamble);
+  std::stringstream log_record;
+  LogPreamble(log_record);
   std::string escaped_message = escape_log_messages_
                                     ? TritonJson::EscapeString(message_.str())
                                     : message_.str();
@@ -152,10 +152,10 @@ LogMessage::~LogMessage()
     std::string escaped_heading = gLogger_.EscapeLogMessages()
                                       ? TritonJson::EscapeString(heading_)
                                       : heading_;
-    preamble << escaped_heading << '\n';
+    log_record << escaped_heading << '\n';
   }
-  preamble << escaped_message;
-  gLogger_.Log(preamble.str());
+  log_record << escaped_message;
+  gLogger_.Log(log_record.str());
 }
 
 }}  // namespace triton::common

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -24,19 +24,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "triton/common/logging.h"
-
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
-
-#include "triton/common/error.h"
 
 // Defined but not used
 #define TRITONJSON_STATUSTYPE uint8_t
 #define TRITONJSON_STATUSRETURN(M)
 #define TRITONJSON_STATUSSUCCESS 0
 
+#include "triton/common/logging.h"
 #include "triton/common/triton_json.h"
 
 namespace triton { namespace common {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -76,7 +76,6 @@ Logger::Flush()
 
 const std::array<const char*, LogMessage::Level::kINFO + 1>
     LogMessage::LEVEL_NAMES_{"ERROR", "WARNING", "INFO"};
-const std::vector<char> LogMessage::level_name_{'E', 'W', 'I'};
 
 #ifdef _WIN32
 
@@ -174,15 +173,16 @@ LogMessage::LogPreamble(std::stringstream& stream)
 
 LogMessage::~LogMessage()
 {
-  gLogger_.SetLogFormat(Logger::Format::kJSONL);
+  //  gLogger_.SetLogFormat(Logger::Format::kJSONL);
 
   switch (gLogger_.LogFormat()) {
     case Logger::Format::kDEFAULT:
     case Logger::Format::kISO8601: {
       std::stringstream preamble;
       LogPreamble(preamble);
-      preamble << message_.rdbuf();
-      message_.str("");
+      //     std::string escaped(message_.str());
+      std::string escaped = TritonJson::EscapeString(message_.str());
+      preamble << escaped;
       gLogger_.Log(preamble.str());
       break;
     }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -46,7 +46,7 @@ Logger gLogger_;
 Logger::Logger()
     : enables_{true, true, true}, vlevel_(0), format_(Format::kDEFAULT)
 {
-  const char* value = std::getenv("TRITON_SERVER_ESCAPE_LOG_MESSAGES");
+  const char* value = std::getenv(Logger::ESCAPE_ENVIRONMENT_VARIABLE);
   escape_log_messages_ =
       (value && std::strcmp(value, "FALSE") == 0) ? false : true;
 }
@@ -67,9 +67,6 @@ Logger::Flush()
 {
   std::cerr << std::flush;
 }
-
-const std::array<const char*, Logger::Level::kEND> Logger::LEVEL_NAMES{
-    "E", "W", "I"};
 
 #ifdef _WIN32
 


### PR DESCRIPTION
- Added support for escaping log messages by default
- Added environment variable to disable escaping
- refactored windows support to simplify deltas
- added macros for logging Protobuf, and Table objects w/o escaping 

### Related PRs

- https://github.com/triton-inference-server/server/pull/7219
- https://github.com/triton-inference-server/core/pull/355

### Log Examples

<details>
  <summary>Original Log Examples</summary>

#### Original Log 
[log_file_orig.log](https://github.com/triton-inference-server/common/files/15327573/log_file_orig.log)

</details>

<details>
  <summary>Log File All Strings Escaped</summary>

#### Log File All Strings Escaped
[log_file_escaped.log](https://github.com/triton-inference-server/common/files/15327571/log_file_escaped.log)

![escaped_table](https://github.com/triton-inference-server/common/assets/15256002/ce9e0fc2-a2a2-46a8-b78e-f88cd45212a1)
![escaped_json](https://github.com/triton-inference-server/common/assets/15256002/8fe10920-20a2-4600-91f6-937a00347e2c)
![escaped_protobuf](https://github.com/triton-inference-server/common/assets/15256002/b0944d63-bd9c-4fed-b464-6c136016bd28)

</details>

<details>
  <summary>Log File with Special Handling for Protobuf, table, and ServerMessage objects</summary>

#### Log File with Special Handling for Protobuf, table, and ServerMessage objects

[log_file_escaped_special_handling.log](https://github.com/triton-inference-server/common/files/15327572/log_file_escaped_special_handling.log)
![special_handling_tables](https://github.com/triton-inference-server/common/assets/15256002/bc9fa168-5c3b-4e89-a056-f475469b6298)
![special_handling_json](https://github.com/triton-inference-server/common/assets/15256002/6d26d62a-9fd8-4329-ae36-2b1dd61ed2be)
![special_handling_protobuf](https://github.com/triton-inference-server/common/assets/15256002/971a6da5-1de7-4249-ae9d-17b912a50c26)

</details>