### PR TITLE
adding explicit include of array needed for some environments

### DIFF
--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <array>
 #include <cerrno>
 #include <cstring>
 #include <fstream>


### PR DESCRIPTION
During compilation in certain environments `std::array` is not being included. 