### PR TITLE
fix: guard windows api definitions in logging.h

### DIFF
--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -36,9 +36,9 @@
 
 #include "table_printer.h"
 #ifdef _WIN32
-// suppress the min and max definitions in Windef.h.
-#define NOMINMAX
-#include <Windows.h>
+// exclude winsock apis
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #else
 #include <sys/time.h>
 #include <sys/types.h>

--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -38,6 +38,8 @@
 #ifdef _WIN32
 // exclude winsock apis
 #define WIN32_LEAN_AND_MEAN
+// suppress the min and max definitions in Windef.h.
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <sys/time.h>


### PR DESCRIPTION
The common logging library is compiled and incorporated as a static library. When including the logging.h file in other projects the winsock apis can conflict and thus we need to guard against including them. 

This is a similar pattern to: 

https://github.com/triton-inference-server/server/blob/ab5bedc63752f4fdfab4c0d8bd8ddf4630e76573/src/main.cc#L29 

