### PR TITLE
fix: Guard windows api definitions in logging.h (#120)

### DIFF
--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -36,9 +36,11 @@
 
 #include "table_printer.h"
 #ifdef _WIN32
+// exclude winsock apis
+#define WIN32_LEAN_AND_MEAN
 // suppress the min and max definitions in Windef.h.
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
Cherry-pick to fix windows server build errors on release branch