### PR TITLE
Fix shape and reformat free tensor handling in the input byte size check

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -248,6 +248,15 @@ class TritonJson {
       return TRITONJSON_STATUSSUCCESS;
     }
 
+    // Set/overwrite a boolean in a value. This changes the
+    // type of the value to boolean.
+    TRITONJSON_STATUSTYPE SetBool(const bool value)
+    {
+      rapidjson::Value& v = AsMutableValue();
+      v.SetBool(value);
+      return TRITONJSON_STATUSSUCCESS;
+    }
+
     // Set/overwrite a signed integer in a value. This changes the
     // type of the value to signed int.
     TRITONJSON_STATUSTYPE SetInt(const int64_t value)

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -410,14 +410,14 @@ message ModelInput
   //@@
   bool optional = 8;
 
-  //@@  .. cpp:var:: bool is_reformat_free_tensor
+  //@@  .. cpp:var:: bool is_non_linear_format_io
   //@@     
-  //@@     Whether or not the input is a reformat-free tensor to the model. This
-  //@@     field is currently supported only for the TensorRT model. An error 
-  //@@     will be generated if this specification does not comply with underlying
+  //@@     Indicates whether the input tensor uses a non-linear IO format. This
+  //@@     field is currently supported only for TensorRT models. An error will 
+  //@@     be generated if this specification does not comply with the underlying
   //@@     model.
   //@@
-  bool is_reformat_free_tensor = 9;
+  bool is_non_linear_format_io = 9;
 }
 
 //@@
@@ -471,14 +471,14 @@ message ModelOutput
   //@@
   bool is_shape_tensor = 6;
 
-  //@@  .. cpp:var:: bool is_reformat_free_tensor
+  //@@  .. cpp:var:: bool is_non_linear_format_io
   //@@     
-  //@@     Whether or not the ouput is a reformat-free tensor to the model. This
-  //@@     field is currently supported only for the TensorRT model. An error 
-  //@@     will be generated if this specification does not comply with underlying
+  //@@     Indicates whether the output tensor uses a non-linear IO format. This
+  //@@     field is currently supported only for TensorRT models. An error will 
+  //@@     be generated if this specification does not comply with the underlying
   //@@     model.
   //@@
-  bool is_reformat_free_tensor = 9;
+  bool is_non_linear_format_io = 9;
 }
 
 //@@  .. cpp:var:: message BatchInput

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -397,7 +397,7 @@ message ModelInput
   //@@     Indicates whether the input tensor uses a non-linear IO format. This
   //@@     field is currently supported only for TensorRT models. An error will
   //@@     be generated if this specification does not comply with the
-  //underlying
+  // underlying
   //@@     model.
   //@@
   bool is_non_linear_format_io = 7;
@@ -477,7 +477,7 @@ message ModelOutput
   //@@     Indicates whether the output tensor uses a non-linear IO format. This
   //@@     field is currently supported only for TensorRT models. An error will
   //@@     be generated if this specification does not comply with the
-  //underlying
+  // underlying
   //@@     model.
   //@@
   bool is_non_linear_format_io = 7;

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -409,6 +409,15 @@ message ModelInput
   //@@     Default value is false.
   //@@
   bool optional = 8;
+
+  //@@  .. cpp:var:: bool is_reformat_free_tensor
+  //@@     
+  //@@     Whether or not the input is a reformat-free tensor to the model. This
+  //@@     field is currently supported only for the TensorRT model. An error 
+  //@@     will be generated if this specification does not comply with underlying
+  //@@     model.
+  //@@
+  bool is_reformat_free_tensor = 9;
 }
 
 //@@
@@ -461,6 +470,15 @@ message ModelOutput
   //@@     model.
   //@@
   bool is_shape_tensor = 6;
+
+  //@@  .. cpp:var:: bool is_reformat_free_tensor
+  //@@     
+  //@@     Whether or not the ouput is a reformat-free tensor to the model. This
+  //@@     field is currently supported only for the TensorRT model. An error 
+  //@@     will be generated if this specification does not comply with underlying
+  //@@     model.
+  //@@
+  bool is_reformat_free_tensor = 9;
 }
 
 //@@  .. cpp:var:: message BatchInput

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -478,7 +478,7 @@ message ModelOutput
   //@@     be generated if this specification does not comply with the underlying
   //@@     model.
   //@@
-  bool is_non_linear_format_io = 9;
+  bool is_non_linear_format_io = 7;
 }
 
 //@@  .. cpp:var:: message BatchInput

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -393,10 +393,11 @@ message ModelInput
   bool is_shape_tensor = 6;
 
   //@@  .. cpp:var:: bool is_non_linear_format_io
-  //@@     
+  //@@
   //@@     Indicates whether the input tensor uses a non-linear IO format. This
-  //@@     field is currently supported only for TensorRT models. An error will 
-  //@@     be generated if this specification does not comply with the underlying
+  //@@     field is currently supported only for TensorRT models. An error will
+  //@@     be generated if this specification does not comply with the
+  //underlying
   //@@     model.
   //@@
   bool is_non_linear_format_io = 7;
@@ -472,10 +473,11 @@ message ModelOutput
   bool is_shape_tensor = 6;
 
   //@@  .. cpp:var:: bool is_non_linear_format_io
-  //@@     
+  //@@
   //@@     Indicates whether the output tensor uses a non-linear IO format. This
-  //@@     field is currently supported only for TensorRT models. An error will 
-  //@@     be generated if this specification does not comply with the underlying
+  //@@     field is currently supported only for TensorRT models. An error will
+  //@@     be generated if this specification does not comply with the
+  //underlying
   //@@     model.
   //@@
   bool is_non_linear_format_io = 7;

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -392,15 +392,14 @@ message ModelInput
   //@@
   bool is_shape_tensor = 6;
 
-  //@@  .. cpp:var:: bool allow_ragged_batch
+  //@@  .. cpp:var:: bool is_non_linear_format_io
+  //@@     
+  //@@     Indicates whether the input tensor uses a non-linear IO format. This
+  //@@     field is currently supported only for TensorRT models. An error will 
+  //@@     be generated if this specification does not comply with the underlying
+  //@@     model.
   //@@
-  //@@     Whether or not the input is allowed to be "ragged" in a dynamically
-  //@@     created batch. Default is false indicating that two requests will
-  //@@     only be batched if this tensor has the same shape in both requests.
-  //@@     True indicates that two requests can be batched even if this tensor
-  //@@     has a different shape in each request.
-  //@@
-  bool allow_ragged_batch = 7;
+  bool is_non_linear_format_io = 7;
 
   //@@  .. cpp:var:: bool optional
   //@@
@@ -410,14 +409,15 @@ message ModelInput
   //@@
   bool optional = 8;
 
-  //@@  .. cpp:var:: bool is_non_linear_format_io
-  //@@     
-  //@@     Indicates whether the input tensor uses a non-linear IO format. This
-  //@@     field is currently supported only for TensorRT models. An error will 
-  //@@     be generated if this specification does not comply with the underlying
-  //@@     model.
+  //@@  .. cpp:var:: bool allow_ragged_batch
   //@@
-  bool is_non_linear_format_io = 9;
+  //@@     Whether or not the input is allowed to be "ragged" in a dynamically
+  //@@     created batch. Default is false indicating that two requests will
+  //@@     only be batched if this tensor has the same shape in both requests.
+  //@@     True indicates that two requests can be batched even if this tensor
+  //@@     has a different shape in each request.
+  //@@
+  bool allow_ragged_batch = 9;
 }
 
 //@@

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -392,15 +392,15 @@ message ModelInput
   //@@
   bool is_shape_tensor = 6;
 
-  //@@  .. cpp:var:: bool is_non_linear_format_io
+  //@@  .. cpp:var:: bool allow_ragged_batch
   //@@
-  //@@     Indicates whether the input tensor uses a non-linear IO format. This
-  //@@     field is currently supported only for TensorRT models. An error will
-  //@@     be generated if this specification does not comply with the
-  // underlying
-  //@@     model.
+  //@@     Whether or not the input is allowed to be "ragged" in a dynamically
+  //@@     created batch. Default is false indicating that two requests will
+  //@@     only be batched if this tensor has the same shape in both requests.
+  //@@     True indicates that two requests can be batched even if this tensor
+  //@@     has a different shape in each request.
   //@@
-  bool is_non_linear_format_io = 7;
+  bool allow_ragged_batch = 7;
 
   //@@  .. cpp:var:: bool optional
   //@@
@@ -410,15 +410,14 @@ message ModelInput
   //@@
   bool optional = 8;
 
-  //@@  .. cpp:var:: bool allow_ragged_batch
+  //@@  .. cpp:var:: bool is_non_linear_format_io
   //@@
-  //@@     Whether or not the input is allowed to be "ragged" in a dynamically
-  //@@     created batch. Default is false indicating that two requests will
-  //@@     only be batched if this tensor has the same shape in both requests.
-  //@@     True indicates that two requests can be batched even if this tensor
-  //@@     has a different shape in each request.
+  //@@     Indicates whether the input tensor uses a non-linear IO format. This
+  //@@     field is currently supported only for TensorRT models. An error will
+  //@@     be generated if this specification does not comply with the
+  //@@     underlying model.
   //@@
-  bool allow_ragged_batch = 9;
+  bool is_non_linear_format_io = 9;
 }
 
 //@@
@@ -477,8 +476,7 @@ message ModelOutput
   //@@     Indicates whether the output tensor uses a non-linear IO format. This
   //@@     field is currently supported only for TensorRT models. An error will
   //@@     be generated if this specification does not comply with the
-  // underlying
-  //@@     model.
+  //@@     underlying model.
   //@@
   bool is_non_linear_format_io = 7;
 }


### PR DESCRIPTION
- Added support for the `is_non_linear_format_io` flag in the model configuration to identify if input/output tensors use a non-linear IO format.