### PR TITLE
feat: Add model_metric message

### DIFF
--- a/include/triton/common/error.h
+++ b/include/triton/common/error.h
@@ -25,8 +25,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace triton { namespace common {
 

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1872,7 +1872,8 @@ message ModelResponseCache
 //@@
 //@@  .. cpp:var:: message ModelMetrics
 //@@
-//@@     The metrics setting of this model.
+//@@     The metrics setting of this model. Consider reusing this message body
+//@@     for backend metric custom configuration.
 //@@
 message ModelMetrics
 {
@@ -1892,8 +1893,9 @@ message ModelMetrics
     {
       //@@  .. cpp:var:: string family
       //@@
-      //@@     The name of the metric family to override
-      //@@     with the custom value.
+      //@@     The name of the metric family to override with the custom value.
+      //@@     Check the list of supported metric families
+      //@@     https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
       //@@
       string family = 1;
     }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1896,7 +1896,7 @@ message ModelMetrics
       //@@     The name of the metric family to override with the custom value.
       //@@     Check the list of supported metric families
       //@@
-      // https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
+      //@@ https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
       //@@
       string family = 1;
     }
@@ -1909,7 +1909,8 @@ message ModelMetrics
     {
       //@@  .. cpp:var:: double buckets (repeated)
       //@@
-      //@@     Repeated double type for histogram bucket boundaries.
+      //@@     Repeated double type in ascending order for histogram bucket
+      //@@     boundaries. For example: [ -5.0, -2, 0, 3.5, 5 ].
       //@@
       repeated double buckets = 1;
     }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1870,6 +1870,75 @@ message ModelResponseCache
 }
 
 //@@
+//@@  .. cpp:var:: message ModelMetrics
+//@@
+//@@     The metrics setting of this model.
+//@@
+message ModelMetrics
+{
+  //@@
+  //@@  .. cpp:var:: message MetricControl
+  //@@
+  //@@     Override metrics settings of this model.
+  //@@
+  message MetricControl
+  {
+    //@@
+    //@@  .. cpp:var:: message MetricIdentifier
+    //@@
+    //@@     Specify metrics to be overridden with metric_option
+    //@@
+    message MetricIdentifier
+    {
+      //@@  .. cpp:var:: string family
+      //@@
+      //@@     The name of the metric family to override
+      //@@     with the custom value.
+      //@@
+      string family = 1;
+    }
+
+    //@@  .. cpp:var:: message HistogramOptions
+    //@@
+    //@@     Histogram metrics options
+    //@@
+    message HistogramOptions {
+      //@@  .. cpp:var:: double buckets (repeated)
+      //@@
+      //@@     Repeated double type
+      //@@
+      repeated double buckets = 1;
+    }
+
+    //@@  .. cpp:var:: MetricIdentifier metric_identifier
+    //@@
+    //@@     The identifier defining metrics to be overridden with the metric_options
+    //@@
+    MetricIdentifier metric_identifier = 1;
+
+    //@@  .. cpp:var:: oneof metric_options
+    //@@
+    //@@     The value to override the metrics defined in metric_identifier.
+    //@@
+    oneof metric_options
+    {
+        //@@  .. cpp:var:: HistogramOptions histogram_options
+        //@@
+        //@@     The custom histogram options.
+        //@@
+        HistogramOptions histogram_options = 2;
+    }
+  }
+
+  //@@
+  //@@  .. cpp::var:: MetricControl metric_control (repeated)
+  //@@
+  //@@     Optional custom configuration for selected metrics.
+  //@@
+  repeated MetricControl metric_control = 1;
+}
+
+//@@
 //@@.. cpp:var:: message ModelConfig
 //@@
 //@@   A model configuration.
@@ -2076,4 +2145,10 @@ message ModelConfig
   //@@     model.
   //@@
   ModelResponseCache response_cache = 24;
+
+  //@@  .. cpp:var:: ModelMetrics model_metrics
+  //@@
+  //@@     Optional setting for custom metrics configuration for this model.
+  //@@
+  ModelMetrics model_metrics = 26;
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1895,7 +1895,8 @@ message ModelMetrics
       //@@
       //@@     The name of the metric family to override with the custom value.
       //@@     Check the list of supported metric families
-      //@@     https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
+      //@@
+      // https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
       //@@
       string family = 1;
     }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1872,8 +1872,9 @@ message ModelResponseCache
 //@@
 //@@  .. cpp:var:: message ModelMetrics
 //@@
-//@@     The metrics setting of this model. Consider reusing this message body
-//@@     for backend metric custom configuration.
+//@@     The metrics setting of this model.
+//@@     NOTE: Consider reusing this message body for backend metric custom
+//@@     configuration.
 //@@
 message ModelMetrics
 {

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1926,7 +1926,7 @@ message ModelMetrics
     {
       //@@  .. cpp:var:: HistogramOptions histogram_options
       //@@
-      //@@     The custom histogram options.
+      //@@     Histogram options.
       //@@
       HistogramOptions histogram_options = 2;
     }
@@ -2151,6 +2151,7 @@ message ModelConfig
   //@@  .. cpp:var:: ModelMetrics model_metrics
   //@@
   //@@     Optional setting for custom metrics configuration for this model.
+  //@@     Application default is applied to metrics that are not specified.
   //@@
   ModelMetrics model_metrics = 26;
 }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1894,7 +1894,7 @@ message ModelMetrics
       //@@  .. cpp:var:: string family
       //@@
       //@@     The name of the metric family to override with the custom value.
-      //@@     Check the list of supported metric families
+      //@@     All core histogram metrics reported by Triton are customizable.
       //@@
       // https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
       //@@
@@ -1910,7 +1910,8 @@ message ModelMetrics
       //@@  .. cpp:var:: double buckets (repeated)
       //@@
       //@@     Repeated double type in ascending order for histogram bucket
-      //@@     boundaries. For example: [ -5.0, -2, 0, 3.5, 5 ].
+      //@@     boundaries. Each value represents a bucket range less than or
+      //@@     equal to itself. For example, [ -5.0, -2, 0, 3.5, 5 ].
       //@@
       repeated double buckets = 1;
     }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1910,8 +1910,10 @@ message ModelMetrics
       //@@  .. cpp:var:: double buckets (repeated)
       //@@
       //@@     Repeated double type in ascending order for histogram bucket
-      //@@     boundaries. Each value represents a bucket range less than or
-      //@@     equal to itself. For example, [ -5.0, -2, 0, 3.5, 5 ].
+      //@@     boundaries. Each bucket value represents a range less than or
+      //@@     equal to itself. The range greater than the largest bucket value
+      //@@     is allocated implicitly.
+      //@@     For example, [ -5.0, -2, 0, 3.5, 5 ].
       //@@
       repeated double buckets = 1;
     }

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1886,7 +1886,7 @@ message ModelMetrics
     //@@
     //@@  .. cpp:var:: message MetricIdentifier
     //@@
-    //@@     Specify metrics to be overridden with metric_option
+    //@@     Specify metrics to be overridden with metric_option.
     //@@
     message MetricIdentifier
     {
@@ -1900,19 +1900,21 @@ message ModelMetrics
 
     //@@  .. cpp:var:: message HistogramOptions
     //@@
-    //@@     Histogram metrics options
+    //@@     Histogram metrics options.
     //@@
-    message HistogramOptions {
+    message HistogramOptions
+    {
       //@@  .. cpp:var:: double buckets (repeated)
       //@@
-      //@@     Repeated double type
+      //@@     Repeated double type for histogram bucket boundaries.
       //@@
       repeated double buckets = 1;
     }
 
     //@@  .. cpp:var:: MetricIdentifier metric_identifier
     //@@
-    //@@     The identifier defining metrics to be overridden with the metric_options
+    //@@     The identifier defining metrics to be overridden with the
+    //@@     metric_options.
     //@@
     MetricIdentifier metric_identifier = 1;
 
@@ -1922,11 +1924,11 @@ message ModelMetrics
     //@@
     oneof metric_options
     {
-        //@@  .. cpp:var:: HistogramOptions histogram_options
-        //@@
-        //@@     The custom histogram options.
-        //@@
-        HistogramOptions histogram_options = 2;
+      //@@  .. cpp:var:: HistogramOptions histogram_options
+      //@@
+      //@@     The custom histogram options.
+      //@@
+      HistogramOptions histogram_options = 2;
     }
   }
 

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1896,7 +1896,7 @@ message ModelMetrics
       //@@     The name of the metric family to override with the custom value.
       //@@     Check the list of supported metric families
       //@@
-      //@@ https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
+      // https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#histograms
       //@@
       string family = 1;
     }


### PR DESCRIPTION
#### What does the PR do?
Tests new model_metrics message in pbtxt. Add example to override histogram buckets per-family.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] feat

#### Related PRs:
https://github.com/triton-inference-server/core/pull/405
https://github.com/triton-inference-server/server/pull/7752

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
L0_metrics

- CI Pipeline ID:
20106057

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
Default histogram buckets does not satisfy all use cases.