### PR TITLE
Suppress deprecation warnings originating in rapidjson

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -38,6 +38,7 @@
 #if defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <rapidjson/document.h>
 #pragma GCC diagnostic pop
 #endif  // _WIN32


### PR DESCRIPTION
Rapidjson's document.h includes use of `std::iterator`, which has been deprecated. Disable deprecated declaration warnings via a GCC diagnostics pragma.