### PR TITLE
fix: Set correct log output stream

### DIFF
--- a/include/triton/common/logging.h
+++ b/include/triton/common/logging.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -141,7 +141,7 @@ class Logger {
   }
 
   // Log a message.
-  void Log(const std::string& msg);
+  void Log(const std::string& msg, const Logger::Level level);
 
   // Flush the log.
   void Flush();

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -48,12 +48,14 @@ Logger::Logger()
 }
 
 void
-Logger::Log(const std::string& msg)
+Logger::Log(const std::string& msg, const Level level)
 {
   const std::lock_guard<std::mutex> lock(mutex_);
   if (file_stream_.is_open()) {
     file_stream_ << msg << std::endl;
-  } else {
+  } else if (level == Level::kINFO) {
+    std::cout << msg << std::endl;
+  } else {  // kWARNING or kERROR
     std::cerr << msg << std::endl;
   }
 }
@@ -152,7 +154,7 @@ LogMessage::~LogMessage()
     log_record << escaped_heading << '\n';
   }
   log_record << escaped_message;
-  gLogger_.Log(log_record.str());
+  gLogger_.Log(log_record.str(), level_);
 }
 
 }}  // namespace triton::common


### PR DESCRIPTION
Previously, all triton logs (INFO, WARNING, ERROR) are written into `stderr`. Changing the output stream of INFO log to `stdout`.

Some common practive I found `stdout` vs `stderr`. As @rmccorm4 mentioned, it seems relatively standard practice to log info stdout and warn/error+ to stderr for enterprise applications.
- https://stackoverflow.com/questions/4919093/should-i-log-messages-to-stderr-or-stdout
- https://overcast.blog/managing-container-stdout-stderr-logs-like-a-pro-e7d42ab0035e

Test PR: https://github.com/triton-inference-server/server/pull/8236