### PR TITLE
doc: Enforce `max_inflight_requests` as a shared limit across ensemble requests

### DIFF
--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1,4 +1,4 @@
-// Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1664,7 +1664,7 @@ message ModelEnsembling
   //@@
   //@@     The maximum number of concurrent in-flight requests allowed at each
   //@@     ensemble step across all ongoing ensemble requests for this model.
-  //@@     This global, per-step limit prevents unbounded memory growth when
+  //@@     This per-step limit prevents unbounded memory growth when
   //@@     ensemble steps produce responses faster than downstream steps can
   //@@     consume them (for example, in decoupled models).
   //@@     The default value is 0, which indicates that no limit is enforced.

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1663,7 +1663,7 @@ message ModelEnsembling
   //@@  .. cpp:var:: uint32 max_inflight_requests
   //@@
   //@@     The maximum number of concurrent in-flight requests allowed at each
-  //@@     ensemble step across all ongoing ensemble requests for this model.
+  //@@     ensemble step across all ongoing ensemble requests for this model instance.
   //@@     This per-step limit prevents unbounded memory growth when
   //@@     ensemble steps produce responses faster than downstream steps can
   //@@     consume them (for example, in decoupled models).

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1662,6 +1662,7 @@ message ModelEnsembling
 
   //@@  .. cpp:var:: uint32 max_inflight_requests
   //@@
+  //@@     BETA  (Subject to change)
   //@@     The maximum number of concurrent in-flight requests allowed at each
   //@@     ensemble step across all ongoing ensemble requests for this model instance.
   //@@     This per-step limit prevents unbounded memory growth when

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1662,11 +1662,12 @@ message ModelEnsembling
 
   //@@  .. cpp:var:: uint32 max_inflight_requests
   //@@
-  //@@     The maximum number of concurrent inflight requests allowed at each
-  //@@     ensemble step per inference request. This limit prevents unbounded
-  //@@     memory growth when ensemble steps produce responses faster than
-  //@@     downstream steps can consume, e.g. decoupled models.
-  //@@     Default value is 0, which indicates that no limit is enforced.
+  //@@     The maximum number of concurrent in-flight requests allowed at each
+  //@@     ensemble step across all ongoing ensemble requests for this model.
+  //@@     This global, per-step limit prevents unbounded memory growth when
+  //@@     ensemble steps produce responses faster than downstream steps can
+  //@@     consume them (for example, in decoupled models).
+  //@@     The default value is 0, which indicates that no limit is enforced.
   //@@
   //@@     Note: Applying this limit may block upstream steps while they wait
   //@@     for downstream capacity. This blocking does not cancel or internally

--- a/protobuf/model_config.proto
+++ b/protobuf/model_config.proto
@@ -1664,8 +1664,8 @@ message ModelEnsembling
   //@@
   //@@     BETA  (Subject to change)
   //@@     The maximum number of concurrent in-flight requests allowed at each
-  //@@     ensemble step across all ongoing ensemble requests for this model instance.
-  //@@     This per-step limit prevents unbounded memory growth when
+  //@@     ensemble step across all ongoing ensemble requests for this model
+  //@@     instance. This per-step limit prevents unbounded memory growth when
   //@@     ensemble steps produce responses faster than downstream steps can
   //@@     consume them (for example, in decoupled models).
   //@@     The default value is 0, which indicates that no limit is enforced.


### PR DESCRIPTION
Related PRs:
https://github.com/triton-inference-server/core/pull/482
https://github.com/triton-inference-server/server/pull/8707