### PR TITLE
build: add Conan 2 + CMakePresets build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,16 @@ option(TRITON_COMMON_ENABLE_JSON "Build json-related libs" ON)
 
 if(TRITON_COMMON_ENABLE_JSON)
   find_package(RapidJSON CONFIG REQUIRED)
+  # Conan-generated config uses a target (rapidjson) rather than the
+  # RAPIDJSON_INCLUDE_DIRS variable.  Populate the variable if empty.
+  if(NOT RAPIDJSON_INCLUDE_DIRS)
+    foreach(_rj_target rapidjson RapidJSON::RapidJSON)
+      if(TARGET ${_rj_target})
+        get_target_property(RAPIDJSON_INCLUDE_DIRS ${_rj_target} INTERFACE_INCLUDE_DIRECTORIES)
+        break()
+      endif()
+    endforeach()
+  endif()
   message(STATUS "RapidJSON found. Headers: ${RAPIDJSON_INCLUDE_DIRS}")
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,4 @@
+{
+  "version": 6,
+  "include": ["cmake/CMakePresets.json"]
+}

--- a/cmake/CMakePresets.json
+++ b/cmake/CMakePresets.json
@@ -1,0 +1,53 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": { "major": 3, "minor": 31, "patch": 8 },
+  "$comment": "Standalone build presets for triton-common. For integrated server builds use server/cmake/CMakePresets.json — it includes common via add_subdirectory and its variables take precedence.",
+  "configurePresets": [
+    {
+      "name": "conan-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "toolchainFile": "${sourceDir}/build/${presetName}/conan/conan_toolchain.cmake",
+      "cacheVariables": { "CMAKE_EXPORT_COMPILE_COMMANDS": "ON" }
+    },
+    {
+      "name": "release",
+      "inherits": "conan-base",
+      "displayName": "Release (gRPC + Metrics)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":             "Release",
+        "TRITON_COMMON_ENABLE_GRPC":    "ON",
+        "TRITON_COMMON_ENABLE_PROTOBUF": "ON",
+        "TRITON_COMMON_ENABLE_JSON":    "ON"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "conan-base",
+      "displayName": "Debug (gRPC + Metrics)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":             "Debug",
+        "TRITON_COMMON_ENABLE_GRPC":    "ON",
+        "TRITON_COMMON_ENABLE_PROTOBUF": "ON",
+        "TRITON_COMMON_ENABLE_JSON":    "ON"
+      }
+    },
+    {
+      "name": "json-only",
+      "inherits": "conan-base",
+      "displayName": "Release JSON-only (no gRPC)",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE":             "Release",
+        "TRITON_COMMON_ENABLE_GRPC":    "OFF",
+        "TRITON_COMMON_ENABLE_PROTOBUF": "OFF",
+        "TRITON_COMMON_ENABLE_JSON":    "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "release",   "configurePreset": "release" },
+    { "name": "debug",     "configurePreset": "debug" },
+    { "name": "json-only", "configurePreset": "json-only" }
+  ]
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,49 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+
+
+class TritonCommonConan(ConanFile):
+    name = "triton-common"
+    version = "2.68.0"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "enable_grpc":    [True, False],
+        "enable_metrics": [True, False],
+    }
+    default_options = {
+        "enable_grpc":    True,
+        "enable_metrics": True,
+    }
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration("triton-common only supports Linux")
+
+    def requirements(self):
+        self.requires("rapidjson/cci.20230929")
+        self.requires("protobuf/3.21.12")
+        if self.options.enable_grpc:
+            self.requires("grpc/1.54.3")
+        if self.options.enable_metrics:
+            self.requires("prometheus-cpp/1.2.4")
+
+    def configure(self):
+        if self.options.enable_grpc:
+            self.options["grpc"].shared = False
+            self.options["grpc"].cpp_plugin = True
+        if self.options.enable_metrics:
+            self.options["prometheus-cpp"].shared = False
+            self.options["prometheus-cpp"].with_pull = False
+            self.options["prometheus-cpp"].with_push = False
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TRITON_COMMON_ENABLE_GRPC"]     = self.options.enable_grpc
+        tc.variables["TRITON_COMMON_ENABLE_PROTOBUF"] = True
+        tc.variables["TRITON_COMMON_ENABLE_JSON"]     = True
+        tc.generate()
+        CMakeDeps(self).generate()

--- a/profiles/linux-gcc13-debug
+++ b/profiles/linux-gcc13-debug
@@ -1,0 +1,13 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=17
+build_type=Debug
+
+[buildenv]
+CC=/usr/bin/gcc-13
+CXX=/usr/bin/g++-13
+PATH=+/home/user/.venv/bin

--- a/profiles/linux-gcc13-release
+++ b/profiles/linux-gcc13-release
@@ -1,0 +1,13 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.cppstd=17
+build_type=Release
+
+[buildenv]
+CC=/usr/bin/gcc-13
+CXX=/usr/bin/g++-13
+PATH=+/home/user/.venv/bin

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -29,7 +29,15 @@ cmake_minimum_required (VERSION 3.31.8)
 set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
 find_package(Protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${Protobuf_VERSION}")
-include_directories(${Protobuf_INCLUDE_DIRS})
+# Prefer target-based includes; fall back to variable for non-Conan builds.
+if(TARGET protobuf::libprotobuf)
+  get_target_property(_proto_incs protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+  if(_proto_incs)
+    include_directories(${_proto_incs})
+  endif()
+elseif(Protobuf_INCLUDE_DIRS)
+  include_directories(${Protobuf_INCLUDE_DIRS})
+endif()
 
 if(${TRITON_COMMON_ENABLE_GRPC})
   find_package(gRPC CONFIG REQUIRED)
@@ -65,6 +73,8 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF})
 
   target_link_libraries(
     proto-library
+    PUBLIC
+      protobuf::libprotobuf
     PRIVATE
       common-compile-settings
   )
@@ -137,6 +147,9 @@ if(${TRITON_COMMON_ENABLE_GRPC})
 
   target_link_libraries(
     grpc-service-library
+    PUBLIC
+      protobuf::libprotobuf
+      gRPC::grpc++
     PRIVATE
       common-compile-settings
   )
@@ -193,6 +206,9 @@ if(${TRITON_COMMON_ENABLE_GRPC})
 
   target_link_libraries(
     grpc-health-library
+    PUBLIC
+      protobuf::libprotobuf
+      gRPC::grpc++
     PRIVATE
       common-compile-settings
   )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -31,11 +31,15 @@ cmake_minimum_required (VERSION 3.31.8)
 #
 include(FetchContent)
 
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/9406a60c7839052e4944ea4dbc8344762a89f9bd.zip
-)
-FetchContent_MakeAvailable(googletest)
+# Prefer GTest from Conan / system; fall back to FetchContent for standalone builds.
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/9406a60c7839052e4944ea4dbc8344762a89f9bd.zip
+  )
+  FetchContent_MakeAvailable(googletest)
+endif()
 
 if (TRITON_COMMON_ENABLE_JSON)
     add_subdirectory(triton_json triton_json)


### PR DESCRIPTION
<sup>
Resolves: TRI-122<br/>
triton-inference-server/backend#123<br/>
triton-inference-server/core#490<br/>
triton-inference-server/server#8734<br/>
triton-inference-server/third_party#74
</sup>

## Description

Introduces Conan 2 package manager and CMakePresets-based build system for dependency management in the common repository, as part of the broader Triton CMake/Conan migration (TRI-122).

## Changes

- build: add Conan 2 + CMakePresets build system

## Affected Files

- CMakeLists.txt
- CMakePresets.json
- cmake/CMakePresets.json
- conanfile.py
- profiles/linux-gcc13-debug
- profiles/linux-gcc13-release
- protobuf/CMakeLists.txt
- src/test/CMakeLists.txt