### PR TITLE
fix: add kParseIterativeFlag when parsing JSON inputs

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -178,7 +178,8 @@ class TritonJsonImpl {
         TRITONJSON_STATUSRETURN(
             std::string("JSON parsing only available for top-level document"));
       }
-      const unsigned int parseFlags = rapidjson::kParseNanAndInfFlag | rapidjson::kParseIterativeFlag;
+      const unsigned int parseFlags =
+          rapidjson::kParseNanAndInfFlag | rapidjson::kParseIterativeFlag;
       document_.Parse<parseFlags>(base, size);
       if (document_.HasParseError()) {
         TRITONJSON_STATUSRETURN(std::string(

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -47,6 +47,7 @@
 #include <rapidjson/error/en.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/rapidjson.h>
+#include <rapidjson/reader.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
@@ -177,7 +178,7 @@ class TritonJsonImpl {
         TRITONJSON_STATUSRETURN(
             std::string("JSON parsing only available for top-level document"));
       }
-      const unsigned int parseFlags = rapidjson::kParseNanAndInfFlag;
+      const unsigned int parseFlags = rapidjson::kParseNanAndInfFlag | rapidjson::kParseIterativeFlag;
       document_.Parse<parseFlags>(base, size);
       if (document_.HasParseError()) {
         TRITONJSON_STATUSRETURN(std::string(


### PR DESCRIPTION
Fixes an issue where a heavily nested JSON input could cause a stack-overflow error.

CI Pipeline ID: 48536419
