### PR TITLE
fix: Switch Triton JSON parsing to iterative mode for deep nesting

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -177,7 +177,10 @@ class TritonJsonImpl {
         TRITONJSON_STATUSRETURN(
             std::string("JSON parsing only available for top-level document"));
       }
-      const unsigned int parseFlags = rapidjson::kParseNanAndInfFlag;
+      // Use iterative parsing so deeply nested JSON does not consume call
+      // stack.
+      const unsigned int parseFlags =
+          rapidjson::kParseNanAndInfFlag | rapidjson::kParseIterativeFlag;
       document_.Parse<parseFlags>(base, size);
       if (document_.HasParseError()) {
         TRITONJSON_STATUSRETURN(std::string(
@@ -771,8 +774,9 @@ class TritonJsonImpl {
     StatusType AsInt(int64_t* value) const
     {
       if ((value_ == nullptr) || !value_->IsInt64()) {
-        TRITONJSON_STATUSRETURN(std::string(
-            "attempt to access JSON non-signed-integer as signed-integer"));
+        TRITONJSON_STATUSRETURN(
+            std::string(
+                "attempt to access JSON non-signed-integer as signed-integer"));
       }
       *value = value_->GetInt64();
       return TRITONJSON_STATUSSUCCESS;
@@ -783,8 +787,10 @@ class TritonJsonImpl {
     StatusType AsUInt(uint64_t* value) const
     {
       if ((value_ == nullptr) || !value_->IsUint64()) {
-        TRITONJSON_STATUSRETURN(std::string(
-            "attempt to access JSON non-unsigned-integer as unsigned-integer"));
+        TRITONJSON_STATUSRETURN(
+            std::string(
+                "attempt to access JSON non-unsigned-integer as "
+                "unsigned-integer"));
       }
       *value = value_->GetUint64();
       return TRITONJSON_STATUSSUCCESS;
@@ -910,8 +916,9 @@ class TritonJsonImpl {
       }
       const auto& v = object[name];
       if (!v.IsInt64()) {
-        TRITONJSON_STATUSRETURN(std::string(
-            "attempt to access JSON non-signed-integer as signed-integer"));
+        TRITONJSON_STATUSRETURN(
+            std::string(
+                "attempt to access JSON non-signed-integer as signed-integer"));
       }
       *value = v.GetInt64();
       return TRITONJSON_STATUSSUCCESS;
@@ -929,8 +936,10 @@ class TritonJsonImpl {
       }
       const auto& v = object[name];
       if (!v.IsUint64()) {
-        TRITONJSON_STATUSRETURN(std::string(
-            "attempt to access JSON non-unsigned-integer as unsigned-integer"));
+        TRITONJSON_STATUSRETURN(
+            std::string(
+                "attempt to access JSON non-unsigned-integer as "
+                "unsigned-integer"));
       }
       *value = v.GetUint64();
       return TRITONJSON_STATUSSUCCESS;
@@ -1101,8 +1110,9 @@ class TritonJsonImpl {
       }
       const auto& v = array[idx];
       if (!v.IsInt64()) {
-        TRITONJSON_STATUSRETURN(std::string(
-            "attempt to access JSON non-signed-integer as signed-integer"));
+        TRITONJSON_STATUSRETURN(
+            std::string(
+                "attempt to access JSON non-signed-integer as signed-integer"));
       }
       *value = v.GetInt64();
       return TRITONJSON_STATUSSUCCESS;
@@ -1120,8 +1130,10 @@ class TritonJsonImpl {
       }
       const auto& v = array[idx];
       if (!v.IsUint64()) {
-        TRITONJSON_STATUSRETURN(std::string(
-            "attempt to access JSON non-unsigned-integer as unsigned-integer"));
+        TRITONJSON_STATUSRETURN(
+            std::string(
+                "attempt to access JSON non-unsigned-integer as "
+                "unsigned-integer"));
       }
       *value = v.GetUint64();
       return TRITONJSON_STATUSSUCCESS;

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -774,9 +774,8 @@ class TritonJsonImpl {
     StatusType AsInt(int64_t* value) const
     {
       if ((value_ == nullptr) || !value_->IsInt64()) {
-        TRITONJSON_STATUSRETURN(
-            std::string(
-                "attempt to access JSON non-signed-integer as signed-integer"));
+        TRITONJSON_STATUSRETURN(std::string(
+            "attempt to access JSON non-signed-integer as signed-integer"));
       }
       *value = value_->GetInt64();
       return TRITONJSON_STATUSSUCCESS;
@@ -787,10 +786,8 @@ class TritonJsonImpl {
     StatusType AsUInt(uint64_t* value) const
     {
       if ((value_ == nullptr) || !value_->IsUint64()) {
-        TRITONJSON_STATUSRETURN(
-            std::string(
-                "attempt to access JSON non-unsigned-integer as "
-                "unsigned-integer"));
+        TRITONJSON_STATUSRETURN(std::string(
+            "attempt to access JSON non-unsigned-integer as unsigned-integer"));
       }
       *value = value_->GetUint64();
       return TRITONJSON_STATUSSUCCESS;
@@ -916,9 +913,8 @@ class TritonJsonImpl {
       }
       const auto& v = object[name];
       if (!v.IsInt64()) {
-        TRITONJSON_STATUSRETURN(
-            std::string(
-                "attempt to access JSON non-signed-integer as signed-integer"));
+        TRITONJSON_STATUSRETURN(std::string(
+            "attempt to access JSON non-signed-integer as signed-integer"));
       }
       *value = v.GetInt64();
       return TRITONJSON_STATUSSUCCESS;
@@ -936,10 +932,8 @@ class TritonJsonImpl {
       }
       const auto& v = object[name];
       if (!v.IsUint64()) {
-        TRITONJSON_STATUSRETURN(
-            std::string(
-                "attempt to access JSON non-unsigned-integer as "
-                "unsigned-integer"));
+        TRITONJSON_STATUSRETURN(std::string(
+            "attempt to access JSON non-unsigned-integer as unsigned-integer"));
       }
       *value = v.GetUint64();
       return TRITONJSON_STATUSSUCCESS;
@@ -1110,9 +1104,8 @@ class TritonJsonImpl {
       }
       const auto& v = array[idx];
       if (!v.IsInt64()) {
-        TRITONJSON_STATUSRETURN(
-            std::string(
-                "attempt to access JSON non-signed-integer as signed-integer"));
+        TRITONJSON_STATUSRETURN(std::string(
+            "attempt to access JSON non-signed-integer as signed-integer"));
       }
       *value = v.GetInt64();
       return TRITONJSON_STATUSSUCCESS;
@@ -1130,10 +1123,8 @@ class TritonJsonImpl {
       }
       const auto& v = array[idx];
       if (!v.IsUint64()) {
-        TRITONJSON_STATUSRETURN(
-            std::string(
-                "attempt to access JSON non-unsigned-integer as "
-                "unsigned-integer"));
+        TRITONJSON_STATUSRETURN(std::string(
+            "attempt to access JSON non-unsigned-integer as unsigned-integer"));
       }
       *value = v.GetUint64();
       return TRITONJSON_STATUSSUCCESS;


### PR DESCRIPTION
This PR updates Triton’s JSON wrapper to parse in RapidJSON iterative mode to avoid call-stack exhaustion when handling deeply nested JSON inputs.

CI: https://github.com/triton-inference-server/server/pull/8745