### PR TITLE
feat: Add `.MemberIsNullIs[type] Functions to TritonJson

### DIFF
--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -1003,8 +1003,9 @@ class TritonJsonImpl {
     bool MemberIsString(const char* name) const
     {
       const rapidjson::Value& object = AsValue();
-      if (!object.IsObject() || !object.HasMember(name))
+      if (!object.IsObject() || !object.HasMember(name)) {
         return false;
+      }
       const auto& v = object[name];
       return v.IsString();
     }

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -961,8 +961,9 @@ class TritonJsonImpl {
     bool MemberIsArray(const char* name) const
     {
       const rapidjson::Value& object = AsValue();
-      if (!object.IsObject() || !object.HasMember(name))
+      if (!object.IsObject() || !object.HasMember(name)) {
         return false;
+      }
       const auto& v = object[name];
       return v.IsArray();
     }

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -975,8 +975,9 @@ class TritonJsonImpl {
     bool MemberIsNull(const char* name) const
     {
       const rapidjson::Value& object = AsValue();
-      if (!object.IsObject() || !object.HasMember(name))
+      if (!object.IsObject() || !object.HasMember(name)) {
         return false;
+      }
       const auto& v = object[name];
       return v.IsNull();
     }

--- a/include/triton/common/triton_json.h
+++ b/include/triton/common/triton_json.h
@@ -958,6 +958,62 @@ class TritonJsonImpl {
       return TRITONJSON_STATUSSUCCESS;
     }
 
+    bool MemberIsArray(const char* name) const
+    {
+      const rapidjson::Value& object = AsValue();
+      if (!object.IsObject() || !object.HasMember(name))
+        return false;
+      const auto& v = object[name];
+      return v.IsArray();
+    }
+
+    bool MemberIsArray(const std::string& name) const
+    {
+      return MemberIsArray(name.c_str());
+    }
+
+    bool MemberIsNull(const char* name) const
+    {
+      const rapidjson::Value& object = AsValue();
+      if (!object.IsObject() || !object.HasMember(name))
+        return false;
+      const auto& v = object[name];
+      return v.IsNull();
+    }
+
+    bool MemberIsNull(const std::string& name) const
+    {
+      return MemberIsNull(name.c_str());
+    }
+
+    bool MemberIsObject(const char* name) const
+    {
+      const rapidjson::Value& object = AsValue();
+      if (!object.IsObject() || !object.HasMember(name))
+        return false;
+      const auto& v = object[name];
+      return v.IsObject();
+    }
+
+    bool MemberIsObject(const std::string& name) const
+    {
+      return MemberIsObject(name.c_str());
+    }
+
+    bool MemberIsString(const char* name) const
+    {
+      const rapidjson::Value& object = AsValue();
+      if (!object.IsObject() || !object.HasMember(name))
+        return false;
+      const auto& v = object[name];
+      return v.IsString();
+    }
+
+    bool MemberIsString(const std::string& name) const
+    {
+      return MemberIsString(name.c_str());
+    }
+
     bool IsString()
     {
       const rapidjson::Value& object = AsValue();


### PR DESCRIPTION
This change adds a set of` .MemberIs[type]` functions to TritonJson.

* `MemberIsArray(const char* name) const`
* `MemberIsArray(const std::string& name) const`
* `MemberIsNull(const char* name) const`
* `MemberIsNull(const std::string& name) const`
* `MemberIsObject(const char* name) const`
* `MemberIsObject(const std::string& name) const`
* `MemberIsString(const char* name) const`
* `MemberIsString(const std::string& name) const`

These new methods are used in parsing of the JSON blobs returned by PyTorch's AOTInductorContainerRunner::get_call_spec() function to determine the interface the model supports.