### PR TITLE
build(deps): Align protobuf and related dependencies with the gRPC v1.81.1 bump

### DIFF
--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -67,6 +67,8 @@ if(${TRITON_COMMON_ENABLE_PROTOBUF})
     proto-library
     PRIVATE
       common-compile-settings
+    PUBLIC
+      protobuf::libprotobuf
   )
 
   set_target_properties(
@@ -139,6 +141,8 @@ if(${TRITON_COMMON_ENABLE_GRPC})
     grpc-service-library
     PRIVATE
       common-compile-settings
+    PUBLIC
+      protobuf::libprotobuf
   )
 
   set_target_properties(

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION
#### What does the PR do?
Fixes the nightly build against protobuf v33 (gRPC v1.81.1 third_party bump): declare `protobuf::libprotobuf` as a `PUBLIC` link dependency of `proto-library` and `grpc-service-library`. With protobuf v33 the include directories and link flags are no longer inherited transitively, so consumers of the generated model-config proto targets failed to compile/link.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Related PRs:
- triton-inference-server/client#908
- triton-inference-server/core#516
- triton-inference-server/perf_analyzer#466
- triton-inference-server/server#8888
- triton-inference-server/third_party#79

#### Where should the reviewer start?
- `protobuf/CMakeLists.txt` — `PUBLIC protobuf::libprotobuf` on both generated targets

#### Test plan:
Nightly build pipeline on internal GitLab CI.

- CI Pipeline ID: 58489960

#### Caveats:
None.

#### Background
The gRPC v1.81.1 / protobuf v33 update in triton-inference-server/third_party#76 broke the nightly build across the Triton repos; this PR chain repairs it.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1608

<sup>
CI (internal): [#58489960](http://tritonserver.local/ci/pipelines/58489960)<br/>
</sup>

